### PR TITLE
fix more one bug with json_dumps

### DIFF
--- a/rxdjango/serialize.py
+++ b/rxdjango/serialize.py
@@ -11,5 +11,5 @@ def default_serializer(value):
     return str(value)
 
 
-def json_dumps(value):    
-    return json.dumps(value, default=default_serializer)
+def json_dumps(value, default=default_serializer):    
+    return json.dumps(value, default=default)


### PR DESCRIPTION
### GOAL

Fix error generated by views passing custom serializer to json_dumps

### SOLUTION

Fix more one bug with json_dumps

- Set default_serializer as parameter to be possible passing to json_dumps function 
a custom serializer

### TEST

- Update rxdjango version on application
- Pass a custom serializer to json_dumps and check if informations is coming right

### TEST ON GLOBAL TRACK

- Enter on project page
- Check if the runs is showing
