### PR TITLE
Fix nested references - proper simulation of a reducer

### DIFF
--- a/rxdjango-react/src/StateBuilder.mock.ts
+++ b/rxdjango-react/src/StateBuilder.mock.ts
@@ -4,6 +4,10 @@ export interface TaskType extends TempInstance {
   taskName: string;
 }
 
+export interface UserType extends TempInstance {
+  username: string;
+}
+
 export interface CustomerType extends TempInstance {
   customerName: string;
   tasks: TaskType[];
@@ -17,6 +21,7 @@ export interface ProjectType extends TempInstance {
 
 export interface TaskPayload extends TempInstance {
   taskName?: string;
+  user?: number;
 }
 
 export interface CustomerPayload extends TempInstance {

--- a/rxdjango-react/src/StateBuilder.mock.ts
+++ b/rxdjango-react/src/StateBuilder.mock.ts
@@ -1,11 +1,12 @@
 import { InstanceType, TempInstance } from './StateChannel.interfaces';
 
-export interface TaskType extends TempInstance {
-  taskName: string;
-}
-
 export interface UserType extends TempInstance {
   username: string;
+}
+
+export interface TaskType extends TempInstance {
+  taskName: string;
+  user?: UserType;
 }
 
 export interface CustomerType extends TempInstance {
@@ -42,8 +43,11 @@ export const MODEL = {
     'customer': 'project.serializers.CustomerSerializer',
     'tasks': 'project.serializers.TaskSerializer',
   },
-  'project.serializers.TaskSerializer': {},
+  'project.serializers.TaskSerializer': {
+    'user': 'project.serializers.UserSerializer',
+  },
   'project.serializers.CustomerSerializer': {
     'tasks': 'project.serializers.TaskSerializer',
   },
+  'project.serializers.UserSerializer': {},
 }

--- a/rxdjango-react/src/StateBuilder.test.ts
+++ b/rxdjango-react/src/StateBuilder.test.ts
@@ -149,7 +149,7 @@ describe('StateBuilder', () => {
     expect(stateBuilder.state!.customer!.tasks).not.toBe(tasks);
   });
 
-  fit('changes the set reference if some child instance changes', () => {
+  it('changes the set reference if some child instance changes', () => {
     const projectInstance: ProjectPayload = {
       ...header('ProjectSerializer', 1),
       projectName: 'Project #1',
@@ -183,9 +183,8 @@ describe('StateBuilder', () => {
     const customer = stateBuilder.state!.customer;
     const customerTasks = stateBuilder.state!.customer!.tasks;
     const user = projectTasks[0].user;
-    
-    stateBuilder.update([userInstance]);
 
+    stateBuilder.update([userInstance]);
 
     expect(project).not.toBe(stateBuilder.state);
     expect(stateBuilder.state!.tasks).not.toBe(projectTasks);

--- a/rxdjango-react/src/StateBuilder.test.ts
+++ b/rxdjango-react/src/StateBuilder.test.ts
@@ -7,6 +7,7 @@ import {
   ProjectPayload,
   CustomerPayload,
   TaskPayload,
+  UserType,
 } from './StateBuilder.mock'
 
 const header = <T>(
@@ -146,6 +147,51 @@ describe('StateBuilder', () => {
     stateBuilder.update([task2]);
     expect(stateBuilder.state!.customer).not.toBe(customer);
     expect(stateBuilder.state!.customer!.tasks).not.toBe(tasks);
+  });
+
+  fit('changes the set reference if some child instance changes', () => {
+    const projectInstance: ProjectPayload = {
+      ...header('ProjectSerializer', 1),
+      projectName: 'Project #1',
+      customer: 2,
+      tasks: [1]
+    };
+
+    const customerInstance: CustomerPayload = {
+      ...header('CustomerSerializer', 2),
+      customerName: 'Customer #2',
+      tasks: [1],
+    };
+
+    const userInstance: UserType = {
+      ...header('UserSerializer', 1),
+      username: 'User #1',
+    };
+
+    const taskInstance: TaskPayload = {
+      ...header('TaskSerializer', 1),
+      taskName: 'Task #1',
+      user: 1,
+    };
+
+    stateBuilder.update([projectInstance]);
+    stateBuilder.update([customerInstance]);
+    stateBuilder.update([taskInstance]);
+
+    const project = stateBuilder.state;
+    const projectTasks = stateBuilder.state!.tasks;
+    const customer = stateBuilder.state!.customer;
+    const customerTasks = stateBuilder.state!.customer!.tasks;
+    const user = projectTasks[0].user;
+    
+    stateBuilder.update([userInstance]);
+
+
+    expect(project).not.toBe(stateBuilder.state);
+    expect(stateBuilder.state!.tasks).not.toBe(projectTasks);
+    expect(stateBuilder.state!.tasks[0].user).not.toBe(user);
+    expect(stateBuilder.state!.customer).not.toBe(customer);
+    expect(stateBuilder.state!.customer!.tasks).not.toBe(customerTasks);
   });
 
   it('initializes foreign key with unloaded object', () => {

--- a/rxdjango-react/src/StateBuilder.ts
+++ b/rxdjango-react/src/StateBuilder.ts
@@ -8,12 +8,31 @@ import {
 
 
 export default class StateBuilder<T> {
-  public state: T | undefined;
+  /***
+   * StateBuilder simulates the behavior of a reducer.
+   * On every instance update, all references to that instance are changed,
+   * and all references to those instances will recusiverly have their
+   * references changed too.
+   * This is expected to do the exact same thing as a reducer would do,
+   * dispatching { ...state, updated_variable } for each update.
+   */
 
+  // The model of the channel with this state
   private model: Model;
+
+  // Anchor is the _instance_type property of the root model
   private anchor: string;
+
+  // The instance id of the anchor for this state
   private anchorId: number | undefined;
+
+  // An index with references for all nodes in the state tree
+  // Key is _instance_type:id properties of instance
   private index: { [key: string]: InstanceType } = {};
+
+  // A track of all references to each instance, so that we can
+  // recursively change references of objects that need to be triggered
+  // in react
   private refs: { [key:string]: InstanceReference[] } = {};
 
   constructor(model: Model, anchor: string) {
@@ -21,44 +40,50 @@ export default class StateBuilder<T> {
     this.anchor = anchor;
   }
 
+  // Returns the current state. Every call returns a different reference.
+  public get state(): T | undefined {
+    if (this.anchorId === undefined)
+      return undefined;
+
+    const stateKey = `${this.anchor}:${this.anchorId}`;
+    return { ...this.index[stateKey] } as T;
+  }
+
+  // Receives an update from the server, with several instances
   public update(instances: TempInstance[]) {
     for (const instance of instances) {
       this.receiveInstance(instance);
     }
-
-    const key = `${this.anchor}:${this.anchorId}`;
-    this.state = { ...this.index[key] } as T;
   }
 
-  private receiveInstance(instance: TempInstance) {
-    const _instance = this.buildInstance(instance);
-
-    if (this.state === undefined) {
-      if (instance._instance_type !== this.anchor) {
-        throw new Error(`Expected _instance_type to be ${this.anchor}, not ${instance._instance_type}`);
-      }
-
-      this.anchorId = instance.id;
-      this.state = _instance as T;
-      const key = `${_instance._instance_type}:${_instance.id}`;
-      this.index[key] = this.state as InstanceType;
-      return;
-    };
-
-    if (instance._instance_type === this.anchor && instance.id === this.anchorId) {
-      this.state = _instance as T;
+  private setAnchor(instance: TempInstance) {
+    if (instance._instance_type !== this.anchor) {
+      throw new Error(`Expected _instance_type to be ${this.anchor}, not ${instance._instance_type}`);
     }
+
+    this.anchorId = instance.id;
   }
 
-  private buildInstance(instance: TempInstance): InstanceType {
+  // Handles data for one instance as received from the backend
+  private receiveInstance(instance: TempInstance) {
+    // The first thing backend sends must be the anchor
+    if (this.anchorId === undefined) {
+      this.setAnchor(instance);
+    }
+
     const _instance = instance as unknown as { [key: string]: any };
+    // The key in the index for this instance
     const key = `${_instance._instance_type}:${_instance.id}`;
+
     let newInstance = (this.index[key] || _instance) as TempInstance;
+    // Change the reference to trigger react
     newInstance = {
       ...newInstance,
       _loaded: true,
     };
     this.index[key] = newInstance as InstanceType;
+
+    // Now change all object ids to objects from index
     const model = this.model[_instance._instance_type];
 
     for (const [property, value] of Object.entries(_instance)) {
@@ -67,9 +92,9 @@ export default class StateBuilder<T> {
         const instanceType = model[property];
         if (Array.isArray(_instance[property])) {
           const ids = _instance[property] as number[];
-          newInstance[property] = ids.map((id, index) => this.getOrCreate(instanceType, id, property, key));
+          newInstance[property] = ids.map((id, index) => this.getOrCreate(instanceType, id, key, property));
         } else {
-          newInstance[property] = this.getOrCreate(instanceType, value, property, key);
+          newInstance[property] = this.getOrCreate(instanceType, value, key, property);
         }
       } else {
         newInstance[property] = value;
@@ -79,13 +104,16 @@ export default class StateBuilder<T> {
     if (!this.refs[key]) {
       this.refs[key] = [];
     } else {
-      this.changeRef(key, newInstance);
+      this.changeRef(key);
     }
 
     return newInstance as unknown as InstanceType;
   }
 
-  private changeRef(key:string, newInstance: TempInstance, track: {[key: string]: true}|null=null) {
+  // Recursively propagate a reference change to all instances affected by an updated
+  // Key is the instance key being changed
+  // Track keeps track of passed instances to avoid infinite recursion
+  private changeRef(key: string, track: {[key: string]: true}|null=null) {
     if (track === null) {
       track = {key: true};
     } else if (track[key]) {
@@ -93,27 +121,31 @@ export default class StateBuilder<T> {
       return;
     }
     for (const ref of this.refs[key]) {
-      const instance = this.index[ref.instanceKey] as any;
-      const property = ref.referenceKey;
+      const instance = this.index[ref.referrerKey] as any;
+      const property = ref.property;
       if (!Array.isArray(instance[property])) {
-        instance[property] = newInstance;
+        instance[property] = this.index[key];
       } else {
         const related = instance[property] as unknown as InstanceType[];
         instance[property] = related.map(
           rel => this.index[`${rel._instance_type}:${rel.id}`]
         );
       }
-      this.changeRef(ref.instanceKey, {...instance}, track);
+      this.index[ref.referrerKey] = {...instance};
+      this.changeRef(ref.referrerKey, track);
     }
   }
 
-  private getOrCreate(instanceType: string, id: number, referenceKey: string, instanceKey: string) {
+  // Gets an instance from index, or create an unloaded one if non-existing
+  // referrerKey and property tracks which instance is linking to this one,
+  // so we track all references.
+  private getOrCreate(instanceType: string, id: number, referrerKey: string, property: string) {
     const pkey = `${instanceType}:${id}`;
     this.index[pkey] ||= {
       id, _instance_type: instanceType, _operation: 'create', _tstamp: 0, _loaded: false
     } as UnloadedInstance;
     this.refs[pkey] ||= [];
-    this.refs[pkey].push({ referenceKey, instanceKey });
+    this.refs[pkey].push({ property, referrerKey });
     return this.index[pkey];
   }
 

--- a/rxdjango-react/src/StateChannel.interfaces.ts
+++ b/rxdjango-react/src/StateChannel.interfaces.ts
@@ -1,32 +1,50 @@
 export type Listener<T> = (state: T) => void;
 export type NoConnectionListener = (no_connection_since: Date | undefined) => void;
 
+// The model for a channel contains which fields for each instance type are references
+// to other types.
+// Key is the _instance_type field (something like myapp.serializer.MyModelSerializer)
 export type Model = {
   [key: string]: ModelEntry;
 }
 
+// key is a property name, value is the instance type the property relates to
 export type ModelEntry = {
   [key: string]: string;
 }
 
+// This represents one instance in the backend, serialized by a serializer.
 export interface InstanceType {
+  // The instance id in database
   id: number;
+  // Instance type is the path of serializer used to serialize it
   _instance_type: string;
+  // The latest operation: created, updated, deleted
   _operation: string;
+  // The timestamp of latest update
   _tstamp: number;
+  // If instance has been deleted already
   _deleted?: boolean;
+  // _loaded is false is instance has been referenced by another
+  // it's set to true once it's data is received from server
   _loaded?: boolean;
 }
 
+// This is a raw instance data as it comes from server
+// It's then converted to an InstanceType
 export interface TempInstance extends InstanceType {
   [index: string]: string | number | object | Date | null | undefined | boolean;
 }
 
+// This is an address of a reference to an instance inside another reference
 export interface InstanceReference {
-  referenceKey: string;
-  instanceKey: string;
+  // The _instance_type:id key of the referring instance
+  referrerKey: string;
+  // The property in the referring instance that points to the referred instance
+  property: string;
 }
 
+// An instance type that has not been loaded yet
 export interface UnloadedInstance extends InstanceType {
   id: number;
   _loaded: false;


### PR DESCRIPTION
Now all references are changed pretty much as a reducer would,
and references not affected by a changed are preserved.
 