### PR TITLE
make makefrontend command explicit

### DIFF
--- a/rxdjango/management/commands/makefrontend.py
+++ b/rxdjango/management/commands/makefrontend.py
@@ -1,0 +1,8 @@
+from django.core.management.base import BaseCommand
+from rxdjango.sdk import make_sdk
+
+class Command(BaseCommand):
+    help="Build the frontend SDK files"
+
+    def handle(self, *args, **kwargs):
+        make_sdk()

--- a/rxdjango/management/commands/runserver.py
+++ b/rxdjango/management/commands/runserver.py
@@ -1,30 +1,14 @@
-from django.apps import apps
-from django.conf import settings
 from daphne.management.commands.runserver import Command as RunserverCommand
-from rxdjango.ts.interfaces import create_app_interfaces
-from rxdjango.ts.channels import create_app_channels
-
+from rxdjango.sdk import make_sdk
 
 class Command(RunserverCommand):
 
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        parser.add_argument('--makefrontend', action='store_true',
+                            help="Build the frontend SDK files")
+
     def inner_run(self, *args, **kwargs):
-        self._make_sdk()
+        if kwargs['makefrontend']:
+            make_sdk()
         super().inner_run(*args, **kwargs)
-
-    def _make_sdk(self):
-        print("Generating RxDjango SDK")
-        self._check()
-
-        models = apps.get_models()
-        installed_apps = list(set([ x.__module__.split('.')[0] for x in models]))
-
-        for app in installed_apps:
-            create_app_interfaces(app)
-            create_app_channels(app)
-
-    def _check(self):
-        if not getattr(settings, 'RX_FRONTEND_DIR', None):
-            raise ProgrammingError(
-                "settings.RX_FRONTEND_DIR is not set. Configure it with a folder "
-                "inside your react application."
-            )

--- a/rxdjango/sdk.py
+++ b/rxdjango/sdk.py
@@ -1,0 +1,25 @@
+from django.apps import apps
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+from rxdjango.ts.interfaces import create_app_interfaces
+from rxdjango.ts.channels import create_app_channels
+
+
+def make_sdk():
+    print("Generating RxDjango SDK")
+    check()
+
+    models = apps.get_models()
+    installed_apps = list(set([ x.__module__.split('.')[0] for x in models]))
+
+    for app in installed_apps:
+        create_app_interfaces(app)
+        create_app_channels(app)
+
+
+def check():
+    if not getattr(settings, 'RX_FRONTEND_DIR', None):
+        raise ImproperlyConfigured(
+            "settings.RX_FRONTEND_DIR is not set. Configure it with a folder "
+            "inside your react application."
+        )


### PR DESCRIPTION
now there's a "makefrontend" command that generates the frontend files (*.channel.ts and *.interfaces.ts), and a parameter --makefrontend to the runserver command, to watch for changes.

the former behavior was an implicit makefrontend on runserver.