### PR TITLE
Support many=True parameter in state's serializer

### DIFF
--- a/rxdjango-react/src/ContextChannel.ts
+++ b/rxdjango-react/src/ContextChannel.ts
@@ -15,6 +15,7 @@ abstract class ContextChannel<T> {
   abstract anchor: string;
   abstract baseURL: string;
   abstract model: Model;
+  abstract many: boolean;
 
   constructor(token: string) {
     this.token = token;
@@ -43,8 +44,9 @@ abstract class ContextChannel<T> {
   }
 
   private notify() {
+    const state = this.builder!.state;
     for (const listener of this.listeners) {
-      if (this.builder!.state) listener(this.builder!.state);
+      if (state) listener(state)
     }
   }
 

--- a/rxdjango-react/src/ContextChannel.ts
+++ b/rxdjango-react/src/ContextChannel.ts
@@ -25,7 +25,7 @@ abstract class ContextChannel<T> {
     if (this.builder)
       return;
 
-    this.builder = new StateBuilder<T>(this.model, this.anchor);
+    this.builder = new StateBuilder<T>(this.model, this.anchor, this.many);
     const ws = new PersistentWebsocket(this.getEndpoint(), this.token);
 
     ws.onclose = this.onclose.bind(this);
@@ -46,7 +46,7 @@ abstract class ContextChannel<T> {
   private notify() {
     const state = this.builder!.state;
     for (const listener of this.listeners) {
-      if (state) listener(state)
+      if (state) listener(state as T);
     }
   }
 

--- a/rxdjango-react/src/StateBuilder.test.ts
+++ b/rxdjango-react/src/StateBuilder.test.ts
@@ -27,7 +27,7 @@ describe('StateBuilder', () => {
   let stateBuilder: StateBuilder<ProjectType>;
 
   beforeEach(() => {
-    stateBuilder = new StateBuilder<ProjectType>(MODEL, ANCHOR);
+    stateBuilder = new StateBuilder<ProjectType>(MODEL, ANCHOR, false);
   });
 
   it('is initialized with an undefined state', () => {
@@ -39,8 +39,9 @@ describe('StateBuilder', () => {
     const instance = { projectName: 'Project #1', ...header('ProjectSerializer', 1) } as ProjectType;
     const instances = [instance];
     stateBuilder.update(instances);
-    expect(stateBuilder.state!.id).toBe(1);
-    expect(stateBuilder.state!.projectName).toBe('Project #1');
+    const state: ProjectType = stateBuilder.state! as ProjectType;
+    expect(state!.id).toBe(1);
+    expect(state!.projectName).toBe('Project #1');
   });
 
   it('initializes related sets with empty lists when there are no related instances', () => {
@@ -52,9 +53,10 @@ describe('StateBuilder', () => {
     ];
 
     stateBuilder.update(instances as TempInstance[]);
-    expect(stateBuilder.state!.id).toBe(1);
-    expect(stateBuilder.state!.projectName).toBe('Project #1');
-    expect(stateBuilder.state!.tasks).toEqual([]);
+    const state: ProjectType = stateBuilder.state! as ProjectType;
+    expect(state!.id).toBe(1);
+    expect(state!.projectName).toBe('Project #1');
+    expect(state!.tasks).toEqual([]);
   });
 
   it('initializes related sets with UnloadedInstance objects', () => {
@@ -62,13 +64,13 @@ describe('StateBuilder', () => {
     const instances = [instance];
 
     stateBuilder.update(instances as TempInstance[]);
-
-    expect(stateBuilder.state?.tasks?.[0]._loaded).toEqual(false);
-    expect(stateBuilder.state?.tasks?.[0].id).toEqual(1);
-    expect(stateBuilder.state?.tasks?.[1]._loaded).toEqual(false);
-    expect(stateBuilder.state?.tasks?.[1].id).toEqual(2);
-    expect(stateBuilder.state?.tasks?.[2]._loaded).toEqual(false);
-    expect(stateBuilder.state?.tasks?.[2].id).toEqual(3);
+    const state: ProjectType = stateBuilder.state! as ProjectType;
+    expect(state?.tasks?.[0]._loaded).toEqual(false);
+    expect(state?.tasks?.[0].id).toEqual(1);
+    expect(state?.tasks?.[1]._loaded).toEqual(false);
+    expect(state?.tasks?.[1].id).toEqual(2);
+    expect(state?.tasks?.[2]._loaded).toEqual(false);
+    expect(state?.tasks?.[2].id).toEqual(3);
   });
 
   it('loads related sets when data is received', () => {
@@ -84,12 +86,13 @@ describe('StateBuilder', () => {
 
     stateBuilder.update([projectInstance]);
     stateBuilder.update([taskInstance]);
-    expect(stateBuilder.state!.tasks?.[0].id).toEqual(taskInstance.id);
-    expect(stateBuilder.state!.tasks?.[0].taskName).toEqual(taskInstance.taskName);
-    expect(stateBuilder.state!.tasks?.[0]._loaded).toEqual(true);
-    expect(stateBuilder.state!.tasks?.[1].id).toEqual(2);
-    expect(stateBuilder.state!.tasks?.[1].taskName).toEqual(undefined);
-    expect(stateBuilder.state!.tasks?.[1]._loaded).toEqual(false);
+    const state: ProjectType = stateBuilder.state! as ProjectType;
+    expect(state!.tasks?.[0].id).toEqual(taskInstance.id);
+    expect(state!.tasks?.[0].taskName).toEqual(taskInstance.taskName);
+    expect(state!.tasks?.[0]._loaded).toEqual(true);
+    expect(state!.tasks?.[1].id).toEqual(2);
+    expect(state!.tasks?.[1].taskName).toEqual(undefined);
+    expect(state!.tasks?.[1]._loaded).toEqual(false);
   });
 
   it('changes the object reference when it is loaded', () => {
@@ -102,18 +105,19 @@ describe('StateBuilder', () => {
       ...header('TaskSerializer', 1),
       taskName: 'Task #1',
     };
+    const state: ProjectType = stateBuilder.state! as ProjectType;
 
     stateBuilder.update([projectInstance]);
-    const task = stateBuilder.state!.tasks![0];
+    const task = state!.tasks![0];
     expect(task._loaded).toEqual(false);
     stateBuilder.update([taskInstance]);
-    const newTask = stateBuilder.state!.tasks![0];
+    const newTask = state!.tasks![0];
     expect(newTask).not.toBe(task);
     expect(newTask._loaded).toEqual(true);
 
     taskInstance.taskName = 'changed';
     stateBuilder.update([taskInstance]);
-    expect(stateBuilder.state!.tasks![0]).not.toBe(newTask);
+    expect(state!.tasks![0]).not.toBe(newTask);
   });
 
   it('changes the middle node reference when child node is updated', () => {
@@ -142,11 +146,13 @@ describe('StateBuilder', () => {
     stateBuilder.update([projectInstance]);
     stateBuilder.update([customerInstance]);
     stateBuilder.update([task1]);
-    const customer = stateBuilder.state!.customer;
-    const tasks = stateBuilder.state!.customer!.tasks;
+    const state: ProjectType = stateBuilder.state! as ProjectType;
+
+    const customer = state!.customer;
+    const tasks = state!.customer!.tasks;
     stateBuilder.update([task2]);
-    expect(stateBuilder.state!.customer).not.toBe(customer);
-    expect(stateBuilder.state!.customer!.tasks).not.toBe(tasks);
+    expect(state!.customer).not.toBe(customer);
+    expect(state!.customer!.tasks).not.toBe(tasks);
   });
 
   it('changes the set reference if some child instance changes', () => {
@@ -179,18 +185,20 @@ describe('StateBuilder', () => {
     stateBuilder.update([taskInstance]);
 
     const project = stateBuilder.state;
-    const projectTasks = stateBuilder.state!.tasks;
-    const customer = stateBuilder.state!.customer;
-    const customerTasks = stateBuilder.state!.customer!.tasks;
+    const state: ProjectType = stateBuilder.state! as ProjectType;
+
+    const projectTasks = state!.tasks;
+    const customer = state!.customer;
+    const customerTasks = state!.customer!.tasks;
     const user = projectTasks[0].user;
 
     stateBuilder.update([userInstance]);
 
-    expect(project).not.toBe(stateBuilder.state);
-    expect(stateBuilder.state!.tasks).not.toBe(projectTasks);
-    expect(stateBuilder.state!.tasks[0].user).not.toBe(user);
-    expect(stateBuilder.state!.customer).not.toBe(customer);
-    expect(stateBuilder.state!.customer!.tasks).not.toBe(customerTasks);
+    expect(project).not.toBe(state);
+    expect(state!.tasks).not.toBe(projectTasks);
+    expect(state!.tasks[0].user).not.toBe(user);
+    expect(state!.customer).not.toBe(customer);
+    expect(state!.customer!.tasks).not.toBe(customerTasks);
   });
 
   it('initializes foreign key with unloaded object', () => {
@@ -199,9 +207,11 @@ describe('StateBuilder', () => {
       projectName: 'Project #1',
       customer: 1,
     };
+    const state: ProjectType = stateBuilder.state! as ProjectType;
+
     stateBuilder.update([projectInstance]);
-    expect(stateBuilder.state?.customer._loaded).toEqual(false);
-    expect(stateBuilder.state?.customer.id).toEqual(1);
+    expect(state?.customer._loaded).toEqual(false);
+    expect(state?.customer.id).toEqual(1);
   });
 
   it('loads foreign key when it arrives, changing reference', () => {
@@ -215,11 +225,13 @@ describe('StateBuilder', () => {
       customerName: 'Customer #5',
     };
     stateBuilder.update([projectInstance]);
-    const customer = stateBuilder.state?.customer
+    const state: ProjectType = stateBuilder.state! as ProjectType;
+
+    const customer = state?.customer
     stateBuilder.update([customerInstance]);
-    expect(stateBuilder.state?.customer._loaded).toEqual(true);
-    expect(stateBuilder.state?.customer.id).toEqual(5);
-    expect(stateBuilder.state?.customer).not.toBe(customer);
+    expect(state?.customer._loaded).toEqual(true);
+    expect(state?.customer.id).toEqual(5);
+    expect(state?.customer).not.toBe(customer);
   });
 
   it('shares the reference of instance when it appears twice, with tasks arriving later', () => {
@@ -236,10 +248,10 @@ describe('StateBuilder', () => {
       ...header('TaskSerializer', 3),
       taskName: 'Task #3',
     }])
+    const state: ProjectType = stateBuilder.state! as ProjectType;
 
-    const st = stateBuilder.state!;
-    const customer = st.customer!;
-    expect(st.tasks[2]).toBe(customer.tasks[0]);
+    const customer = state.customer!;
+    expect(state.tasks[2]).toBe(customer.tasks[0]);
   });
 
   it('shares the reference of instance when it appears twice, with tasks arriving early', () => {
@@ -257,9 +269,9 @@ describe('StateBuilder', () => {
       tasks: [3, 4, 5],
     }])
 
-    const st = stateBuilder.state!;
-    const customer = st.customer!;
-    expect(st.tasks[2]).toBe(customer.tasks[0]);
+    const state: ProjectType = stateBuilder.state! as ProjectType;
+    const customer = state.customer!;
+    expect(state.tasks[2]).toBe(customer.tasks[0]);
   });
 
 });

--- a/rxdjango-react/src/StateBuilder.ts
+++ b/rxdjango-react/src/StateBuilder.ts
@@ -35,9 +35,12 @@ export default class StateBuilder<T> {
   // in react
   private refs: { [key:string]: InstanceReference[] } = {};
 
-  constructor(model: Model, anchor: string) {
+  private many: boolean;
+
+  constructor(model: Model, anchor: string, many: boolean) {
     this.model = model;
     this.anchor = anchor;
+    this.many = many;
   }
 
   // Returns the current state. Every call returns a different reference.
@@ -51,19 +54,22 @@ export default class StateBuilder<T> {
     if (!this.many) {
       return { ...this.index[stateKeys[0]] } as T;
     }
-    return stateKeys.map((stateKey: string): T[] => {
+    return stateKeys.map((stateKey: string): T => {
       return { ...this.index[stateKey] } as T;
     });
   }
 
   // Receives an update from the server, with several instances
-  public update(instances: TempInstance[]) {
-    if (this.many && this.anchorIds === undefined) {
+  public update(instances: TempInstance[] | number[]) {
+    if (typeof instances[0] === 'number' && this.many && this.anchorIds === undefined) {
       this.setAnchors(instances as number[]);
       return;
-    }
-    for (const instance of instances) {
-      this.receiveInstance(instance);
+    } else if (typeof instances[0] === 'object') {
+      for (const instance of instances) {
+        this.receiveInstance(instance as TempInstance);
+      }
+    } else {
+      throw new Error('Expected first array of ids then arrays of instances');
     }
   }
 

--- a/rxdjango-react/src/hook.ts
+++ b/rxdjango-react/src/hook.ts
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
 import ContextChannel from './ContextChannel';
 
-export const useChannelState = <T>(channel: ContextChannel<T>) => {
-  const [state, setReactState] = useState<T | undefined>(undefined);
-  const [noConnectionSince, setNoConnectionSince] = useState<Date | undefined>(undefined);
+export const useChannelState = <T>(channel: ContextChannel<T | T[]>) => {
+  const [state, setReactState] = useState<T | T[]>();
+  const [noConnectionSince, setNoConnectionSince] = useState<Date>();
 
   useEffect(() => {
     // FIX: passing twice here

--- a/rxdjango/consumers.py
+++ b/rxdjango/consumers.py
@@ -68,6 +68,7 @@ class StateConsumer(AsyncWebsocketConsumer):
         kwargs = self.scope['url_route']['kwargs']
         self.user = user
         self.channel = self.context_channel_class(user, **kwargs)
+        await self.channel.initialize_anchors()
         self.user_id = self.user.id
         self.anchor_ids = self.channel.anchor_ids
         self.wsrouter = self.channel._wsrouter
@@ -75,7 +76,7 @@ class StateConsumer(AsyncWebsocketConsumer):
         await self.send_connection_status(200)
 
         if self.channel.many:
-            self.send(text_data=json.dumps(self.anchor_ids))
+            await self.send(text_data=json.dumps(self.anchor_ids))
 
         for anchor_id in self.anchor_ids:
             await self._connect_anchor(anchor_id)

--- a/rxdjango/management/commands/makefrontend.py
+++ b/rxdjango/management/commands/makefrontend.py
@@ -13,12 +13,15 @@ class Command(BaseCommand):
                             help="Do not write any changes")
 
         parser.add_argument('--quiet', action='store_true',
-                            help="Do not write any changes")
+                            help="Do not output logs")
+        parser.add_argument('--force', '-f', action='store_true',
+                            help="Rebuild all files regardless of changes")
 
 
     def handle(self, *args, **kwargs):
         changed = make_sdk(
             not kwargs['dry_run'],
             kwargs['quiet'],
+            kwargs['force'],
         )
         sys.exit(1 if changed else 0)

--- a/rxdjango/mongo.py
+++ b/rxdjango/mongo.py
@@ -13,9 +13,9 @@ from .serialize import json_dumps
 
 class MongoStateSession:
 
-    def __init__(self, channel):
+    def __init__(self, channel, anchor_id):
         self.channel = channel
-        self.anchor_id = channel.anchor_id
+        self.anchor_id = anchor_id
         self.user_id = channel.user_id
         self.state_model = channel._state_model
         self._tstamp = None

--- a/rxdjango/redis.py
+++ b/rxdjango/redis.py
@@ -61,11 +61,11 @@ class RedisSession:
         'relay_writers_trigger',
     ]
 
-    def __init__(self, channel):
+    def __init__(self, channel, anchor_id):
         self.channel = channel
 
         self.local_keys = [
-            _make_key(channel.name, channel.anchor_id, key)
+            _make_key(channel.name, anchor_id, key)
             for key in self.KEYS
         ]
 
@@ -101,8 +101,8 @@ class RedisSession:
 
 class RedisStateSession(RedisSession):
 
-    def __init__(self, channel):
-        super().__init__(channel)
+    def __init__(self, channel, anchor_id):
+        super().__init__(channel, anchor_id)
         self.initial_state = None
         self.tstamp = None
 

--- a/rxdjango/sdk.py
+++ b/rxdjango/sdk.py
@@ -5,7 +5,7 @@ from rxdjango.ts.interfaces import create_app_interfaces
 from rxdjango.ts.channels import create_app_channels
 
 
-def make_sdk(apply_changes=True, quiet=False):
+def make_sdk(apply_changes=True, quiet=False, force=False):
     print("Generating RxDjango SDK")
     check()
 
@@ -19,11 +19,11 @@ def make_sdk(apply_changes=True, quiet=False):
     changed = False
 
     for app in installed_apps:
-        diff = create_app_interfaces(app, apply_changes)
+        diff = create_app_interfaces(app, apply_changes, force)
         if diff:
             changed = True
             log(diff)
-        diff = create_app_channels(app, apply_changes)
+        diff = create_app_channels(app, apply_changes, force)
         if diff:
             changed = True
             log(diff)

--- a/rxdjango/state_loader.py
+++ b/rxdjango/state_loader.py
@@ -32,14 +32,14 @@ class StateLoader:
         base_key (str): The base key used for all Redis keys related to this anchor ID.
     """
 
-    def __init__(self, channel):
+    def __init__(self, channel, anchor_id):
         self.channel = channel
         self.state_model = channel._state_model
 
-        self.redis = RedisStateSession(channel)
-        self.mongo = MongoStateSession(channel)
+        self.redis = RedisStateSession(channel, anchor_id)
+        self.mongo = MongoStateSession(channel, anchor_id)
 
-        self.anchor_id = channel.anchor_id
+        self.anchor_id = anchor_id
         self.user_id = channel.user_id
 
         self.cache_state = None

--- a/rxdjango/state_model.py
+++ b/rxdjango/state_model.py
@@ -26,7 +26,11 @@ class StateModel:
             self.query_path = origin.query_path[:] + [query_property]
             self.index = origin.index
 
-        meta = state_serializer.Meta
+        try:
+            meta = state_serializer.Meta
+        except AttributeError:
+            meta = state_serializer.child.Meta
+
         self.model = meta.model
 
         if origin:

--- a/rxdjango/ts/channels.py
+++ b/rxdjango/ts/channels.py
@@ -10,7 +10,6 @@ from . import header, interface_name, diff
 
 def create_app_channels(app, apply_changes=True, force=False):
     consumer_urlpatterns = list_consumer_patterns(app)
-
     if not consumer_urlpatterns:
         return
 
@@ -168,6 +167,11 @@ def generate_ts_class(context_channel_class, urlpattern, import_types):
 
     name = context_channel_class.__name__
     anchor = context_channel_class.Meta.state
+    if context_channel_class.many:
+        many = 'true'
+        anchor = anchor.child
+    else:
+        many = 'false'
 
     anchor_module = anchor.__class__.__module__
     anchor_name = anchor.__class__.__name__
@@ -185,6 +189,7 @@ def generate_ts_class(context_channel_class, urlpattern, import_types):
         f"  anchor = '{anchor_module}.{anchor_name}';",
         f"  endpoint: string = '{endpoint}';\n",
         f"  args: {{ [key: string]: number | string }} = {{}};\n",
+        f"  many = {many};\n",
     ]
 
     # Add private properties based on parameters

--- a/rxdjango/ts/channels.py
+++ b/rxdjango/ts/channels.py
@@ -8,7 +8,7 @@ from django.conf import settings
 from rxdjango.consumers import StateConsumer
 from . import header, interface_name, diff
 
-def create_app_channels(app, apply_changes=True):
+def create_app_channels(app, apply_changes=True, force=False):
     consumer_urlpatterns = list_consumer_patterns(app)
 
     if not consumer_urlpatterns:
@@ -27,7 +27,7 @@ def create_app_channels(app, apply_changes=True):
     existing = []
 
     if os.path.exists(ts_file_path):
-        if py_mtime == os.path.getmtime(ts_file_path):
+        if not force and py_mtime == os.path.getmtime(ts_file_path):
             return
         with open(ts_file_path, 'r') as file:
             existing = file.read().split('\n')

--- a/rxdjango/ts/interfaces.py
+++ b/rxdjango/ts/interfaces.py
@@ -11,7 +11,7 @@ from django.conf import settings
 from rest_framework import serializers, relations, fields
 from . import ts_exported, header, interface_name, diff
 
-def create_app_interfaces(app, apply_changes=True):
+def create_app_interfaces(app, apply_changes=True, force=False):
     serializer_module_name = f'{app}.serializers'
     serializer_path = serializer_module_name.replace('.', '/') + '.py'
 
@@ -24,7 +24,7 @@ def create_app_interfaces(app, apply_changes=True):
     existing = []
 
     if os.path.exists(ts_file_path):
-        if py_mtime == os.path.getmtime(ts_file_path):
+        if not force and py_mtime == os.path.getmtime(ts_file_path):
             return
         with open(ts_file_path, 'r') as file:
             existing = file.read().split('\n')


### PR DESCRIPTION
Add support in ContextChannel for a queryset with several objects as anchors.