### PR TITLE
ContextChannel.list_instances may return a list of ids

### DIFF
--- a/rxdjango/channels.py
+++ b/rxdjango/channels.py
@@ -126,7 +126,13 @@ class ContextChannel(metaclass=ContextChannelMeta):
     async def initialize_anchors(self):
         if self.many:
             qs = await self.list_instances(**self.kwargs)
-            await self._fetch_instance_ids(qs)
+            if isinstance(qs, models.query.QuerySet):
+                self.anchor_ids = await self._fetch_instance_ids(qs)
+            elif len(qs) == 0:
+                self.anchor_ids = []
+            else:
+                assert type(qs[0]) is int
+                self.anchor_ids = qs
         else:
             self.anchor_ids = [
                 self.get_instance_id(**self.kwargs)
@@ -134,7 +140,7 @@ class ContextChannel(metaclass=ContextChannelMeta):
             
     @database_sync_to_async
     def _fetch_instance_ids(self, qs):
-        self.anchor_ids = [
+                    return [
                 instance['id'] for instance in qs.values('id')
             ]
 


### PR DESCRIPTION
this allows caching