### PR TITLE
Optimize delta calculations in C

### DIFF
--- a/rxdjango/utils/delta_utils.c
+++ b/rxdjango/utils/delta_utils.c
@@ -1,0 +1,84 @@
+#include <Python.h>
+#include <string.h>
+
+static PyObject* generate_delta(PyObject* self, PyObject* args) {
+    PyObject *original, *instance;
+    PyObject *key, *old_value, *new_value;
+    Py_ssize_t pos = 0;
+    int empty = 1;
+
+    if (!PyArg_ParseTuple(args, "OO", &original, &instance)) {
+        return NULL;
+    }
+
+    if (!PyDict_Check(original) || !PyDict_Check(instance)) {
+        PyErr_SetString(PyExc_TypeError, "Both arguments must be dictionaries");
+        return NULL;
+    }
+
+    // Iterate through original dictionary
+    while (PyDict_Next(original, &pos, &key, &old_value)) {
+        // Skip if key is 'id' or starts with '_'
+        if (PyUnicode_Check(key)) {
+            const char *key_str = PyUnicode_AsUTF8(key);
+            if (strcmp(key_str, "id") == 0 || key_str[0] == '_') {
+                continue;
+            }
+        }
+
+        // Get the new value from instance
+        new_value = PyDict_GetItem(instance, key);
+        if (!new_value) {
+            continue;  // Key not found, skip as in original Python code
+        }
+
+        // Compare values
+        int cmp = PyObject_RichCompareBool(old_value, new_value, Py_EQ);
+        if (cmp == -1) {
+            return NULL;  // Error in comparison
+        }
+
+        if (cmp == 1) {
+            // Values are equal, remove from instance copy
+            if (PyDict_DelItem(instance, key) == -1) {
+                return NULL;
+            }
+        } else {
+            // Values are different
+            empty = 0;
+        }
+    }
+
+    // Create a new list for deltas
+    PyObject *deltas = PyList_New(0);
+    if (!deltas) {
+        return NULL;
+    }
+
+    // If not empty, append to deltas
+    if (!empty) {
+        if (PyList_Append(deltas, instance) == -1) {
+            Py_DECREF(deltas);
+            return NULL;
+        }
+    }
+
+    return deltas;
+}
+
+static PyMethodDef DeltaMethods[] = {
+    {"generate_delta", generate_delta, METH_VARARGS, "Generate delta between two objects"},
+    {NULL, NULL, 0, NULL}
+};
+
+static struct PyModuleDef deltamodule = {
+    PyModuleDef_HEAD_INIT,
+    "delta_utils_c",
+    NULL,
+    -1,
+    DeltaMethods
+};
+
+PyMODINIT_FUNC PyInit_delta_utils_c(void) {
+    return PyModule_Create(&deltamodule);
+}

--- a/rxdjango/utils/delta_utils.py
+++ b/rxdjango/utils/delta_utils.py
@@ -1,0 +1,30 @@
+# There is a C version of this library, at delta_utils.py,
+# with the exact same interface and functionality, it exports
+# module as delta_utils_c
+
+def generate_delta(original, instance):
+    # Removes from instance all keys that are the same as original.
+    # Returns a list containing instance with removed fields, or an
+    # empty list if there are no different fields.
+
+    deltas = []
+    empty = True
+    for key, old_value in original.items():
+        if key == 'id' or key.startswith('_'):
+            continue
+        try:
+            new_value = instance[key]
+        except KeyError:
+            # An exception in a property may have generated
+            # an incomplete serialized object.
+            # TODO emit a warning
+            continue
+        if new_value == old_value:
+            del instance[key]
+        else:
+            empty = False
+
+    if not empty:
+        deltas.append(instance)
+
+    return deltas

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,14 @@
-from setuptools import setup, find_packages
+from setuptools import setup, find_packages, Extension
 from os import path
 
 cur_dir = path.abspath(path.dirname(__file__))
 
 VERSION = '0.0.37'
+
+delta_utils = Extension(
+    'rxdjango.utils.delta_utils_c',
+    sources=['rxdjango/utils/delta_utils.c'],
+)
 
 setup(
     name="rxdjango",
@@ -23,5 +28,6 @@ setup(
     ],
     url="https://github.com/CDIGlobalTrack/rxdjango",
     include_package_data=True,
-    python_requires=">=3.10"
+    python_requires=">=3.10",
+    ext_modules=[delta_utils],
 )


### PR DESCRIPTION
Every time an instance is saved, the new version is serialized and it's compared with the current version in cache, so only deltas are sent to clients. This commit separates this routine in the rxdjango.utils.delta_utils module and creates a rxdjango.utils.delta_utils_c module which has the same interface and implemented in C.

The mongo code will try to get the C implementation first, then use the python one if C is not available.

Profiling shows this is 2.3 - 1.6 times faster