### PR TITLE
Remove parent checking

### DIFF
--- a/rxdjango/signal_handler.py
+++ b/rxdjango/signal_handler.py
@@ -184,12 +184,15 @@ class SignalHandler:
                 weak=False,
             )
 
-        pre_save.connect(
-            prepare_save,
-            sender=layer.model,
-            dispatch_uid=f'{uid}-prepare-save',
-            weak=False,
-        )
+        # This pre saving is not good.
+        # Commenting this out to see what breaks
+        #
+        # pre_save.connect(
+        #     prepare_save,
+        #     sender=layer.model,
+        #     dispatch_uid=f'{uid}-prepare-save',
+        #     weak=False,
+        # )
 
         post_save.connect(
             relay_instance,


### PR DESCRIPTION
This feature seems to have bugs, uses resorces and is not required in most cases. Maybe it's better to leave for developer to do it manually.

I'm commenting this out now to see what breaks.