### PR TITLE
Remove support for "optimistic" flag in serializer

### DIFF
--- a/docs/architecture-overview.rst
+++ b/docs/architecture-overview.rst
@@ -14,8 +14,7 @@ Each *ContextChannel* subclass must contain a *Meta* class declaring
 the *state* property, which must be an instance of `rest_framework.serializers.ModelSerializer`.
 Usually, this is a nested serializer with many layers of serializers.
 RxDjango splits the nested serializer into several flat serializers
-and iterate to register a post_save signal for each of them (and maybe
-a pre_save too, if the Meta class has *optimistic* set to True).
+and iterate to register a post_save signal for each of them.
 
 These signals will serialize each instance that composes the nested
 serialization structure, broadcast them to all connected clients and


### PR DESCRIPTION
This was causing bugs during e2e tests and not helping with general latency.

A new approach to optimistic will be to distribute the edited serialized object from frontend before saving it.