### PR TITLE
Fix TypeError when broadcasting delete operations inside transactions

### DIFF
--- a/rxdjango/state_model.py
+++ b/rxdjango/state_model.py
@@ -131,6 +131,12 @@ class StateModel:
         data['_operation'] = 'delete'
         return data
 
+    def serialize_delete_by_id(self, instance_id: int, tstamp: float) -> dict[str, Any]:
+        data = self._mark({'id': instance_id}, tstamp)
+        data['_deleted'] = True
+        data['_operation'] = 'delete'
+        return data
+
     def serialize_state(self, instance: Model, tstamp: float) -> Generator[list[dict[str, Any]], None, None]:
         if self.many:
             data = self.flat_serializer(instance.all(), many=True).data

--- a/rxdjango/tests/test_transaction_manager.py
+++ b/rxdjango/tests/test_transaction_manager.py
@@ -53,6 +53,47 @@ class TestPendingBroadcast(unittest.TestCase):
         assert serialized['_tstamp'] == 1234567890.123
         assert serialized['_deleted'] is True
 
+    def test_delete_operation_without_preserialized_data_crashes(self):
+        """Delete with delete_serialized=None should not crash.
+
+        Reproduces the bug where broadcast_instance() creates a
+        PendingBroadcast for a delete operation without passing
+        delete_serialized, causing:
+          TypeError: 'NoneType' object does not support item assignment
+        """
+        mock_handler = Mock()
+        mock_handler._relay = Mock()
+
+        mock_state_model = Mock()
+        mock_state_model.serialize_delete_by_id = Mock(return_value={
+            'id': 417,
+            '_instance_type': 'test.TestSerializer',
+            '_tstamp': 1234567890.123,
+            '_operation': 'delete',
+            '_deleted': True,
+            '_user_key': None,
+        })
+
+        # This is the buggy case: delete operation without pre-serialized data
+        pending = PendingBroadcast(
+            model_class=Mock,
+            instance_id=417,
+            state_model=mock_state_model,
+            operation='delete',
+            # No anchors or delete_serialized passed - this is the bug
+        )
+
+        # This should NOT raise TypeError
+        pending.serialize_and_relay(mock_handler, tstamp=1234567890.123)
+
+        # Should still relay a delete broadcast
+        mock_handler._relay.assert_called_once()
+        call_args = mock_handler._relay.call_args
+        serialized = call_args[0][0]
+        assert serialized['id'] == 417
+        assert serialized['_tstamp'] == 1234567890.123
+        assert serialized['_deleted'] is True
+
     def test_update_operation_fetches_fresh_from_db(self):
         """Update operations should fetch fresh instance from DB."""
         mock_handler = Mock()

--- a/rxdjango/transaction_manager.py
+++ b/rxdjango/transaction_manager.py
@@ -58,8 +58,16 @@ class PendingBroadcast:
         """
         if self.operation == 'delete':
             # Use pre-computed serialized data for deletions
-            serialized = self.delete_serialized
-            serialized['_tstamp'] = tstamp
+            if self.delete_serialized is not None:
+                serialized = self.delete_serialized
+                serialized['_tstamp'] = tstamp
+            else:
+                # Fallback: delete_serialized wasn't provided (e.g. from
+                # broadcast_instance or parent-change scheduling).
+                # Build a minimal delete payload from what we have.
+                serialized = self.state_model.serialize_delete_by_id(
+                    self.instance_id, tstamp
+                )
             handler._relay(serialized, self.state_model, self.anchors)
             return
 


### PR DESCRIPTION
PendingBroadcast for delete ops created by broadcast_instance() and parent-change scheduling lacked delete_serialized, causing 'NoneType' object does not support item assignment at commit time. Added serialize_delete_by_id() fallback for when the instance is already gone.