### PR TITLE
feat: replace RuntimeState with reactive() field API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,84 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - TBD
+
+### Added
+- `rxdjango.state.reactive()` — declare reactive fields on `ContextChannel`
+  subclasses as ordinary class-level attributes with type annotations. Reads
+  and writes use plain attribute syntax (`self.count += 1`).
+- Auto-proxy for mutable container reactive fields (`list`, `dict`, `set`):
+  in-place mutations (`.append()`, `[key] = v`, `.add()`, `.clear()`, etc.)
+  broadcast automatically without requiring reassignment.
+- `ContextChannel.batch()` — async context manager for atomic multi-field
+  reactive updates. All changes inside the block are buffered and sent as a
+  single `runtimeVars` WebSocket message on exit.
+- `runtimeVars` wire message — new batch variant of `runtimeVar`, also sent
+  on initial connect with all reactive field defaults.
+- `_annotation_to_ts()` in the TypeScript generator — maps Python generic
+  annotations (`list[int]`, `dict[str, bool]`, `Optional[str]`) to TypeScript
+  types for the generated `RuntimeState` interface.
+
+### Breaking Changes
+- **Removed** `ContextChannel.RuntimeState` nested `TypedDict` class pattern.
+- **Removed** `ContextChannel.runtime_state` dict attribute.
+- **Removed** `ContextChannel.set_runtime_var(name, value)` async method.
+- Reactive state is per-connection and resets to defaults on reconnect.
+  It was previously also per-connection but had no explicit reset guarantee.
+
+### Migration
+Replace the old pattern:
+
+```python
+from typing import TypedDict
+from rxdjango.channels import ContextChannel
+
+class MyChannel(ContextChannel):
+    class RuntimeState(TypedDict):
+        notifications: int
+
+    async def some_handler(self, event):
+        n = self.runtime_state['notifications']
+        await self.set_runtime_var('notifications', n + 1)
+```
+
+With:
+
+```python
+from rxdjango.channels import ContextChannel
+from rxdjango.state import reactive
+
+class MyChannel(ContextChannel):
+    notifications: int = reactive(default=0)
+
+    async def some_handler(self, event):
+        self.notifications += 1
+```
+
+## [0.3.0] - unreleased
+
+### Changed (breaking)
+- **Reactive state API** — `RuntimeState` nested class, `runtime_state` dict,
+  and `set_runtime_var()` method have been removed. Replace them with
+  `reactive()` field declarations at the class level (see docs/using-rxdjango.rst).
+
+### Added
+- `rxdjango.state.reactive(default=…, default_factory=…)` — declare reactive
+  fields on a `ContextChannel` subclass as ordinary class-level attributes.
+  Reads and writes are plain attribute access; no dicts or method calls needed.
+- Auto-proxy for mutable containers: `list`, `dict`, and `set` reactive fields
+  are wrapped transparently so in-place mutations (`.append()`, `[k]=v`,
+  `.add()`, etc.) broadcast automatically.
+- `ContextChannel.batch()` — async context manager for atomic multi-field
+  updates. All writes inside the block are buffered and sent as a single
+  `runtimeVars` WebSocket message on exit. On exception, buffered changes
+  are discarded with transactional rollback semantics.
+- New `runtimeVars` WebSocket message type (plural) for batched updates and
+  for the initial reactive-state snapshot sent after connection.
+- `_annotation_to_ts()` in the TypeScript generator — handles generic
+  annotations (`list[int]`, `dict[str, bool]`, `Optional[X]`, etc.) for
+  reactive field interface generation.
+
 ## [0.0.44] - 2026-02-19
 
 ### Changed

--- a/Runtime-Refactor-FDD.md
+++ b/Runtime-Refactor-FDD.md
@@ -1,0 +1,460 @@
+# Feature Design Doc: Runtime State Refactor
+
+**Target release:** v0.3.0
+**Status:** Approved, ready to implement
+**Compatibility:** Breaking change. No deprecation shims. No users other than the core team.
+
+---
+
+## 1. Motivation
+
+The current `RuntimeState` API is not idiomatic Python. Users declare a `TypedDict` nested in their channel class, then read values with dict lookups and write them with a method call that takes a stringly-typed name:
+
+```python
+class MyChannel(ContextChannel):
+
+    class RuntimeState(TypedDict):
+        notifications: int
+
+    @consumer('new.notification')
+    async def relay(self, event):
+        n = self.runtime_state['notifications']       # dict read
+        await self.set_runtime_var('notifications', n + 1)   # string-keyed setter
+```
+
+Problems, in order of severity:
+
+1. Read/write asymmetry — dict access for read, method call for write, same concept.
+2. Stringly-typed writes — `'notifications'` is a string; typos are runtime errors and renames need grep.
+3. `TypedDict` was chosen to satisfy the TypeScript generator, not to serve the Python developer.
+4. Two names for one concept — `RuntimeState` (the class) and `runtime_state` (the dict).
+5. `await` on every write, even though the user is just changing a value.
+6. No place to declare defaults.
+7. "Var" is C-brained. Python says *attribute*.
+
+## 2. The new API
+
+Reactive fields declared at the class level as descriptors, read and written as ordinary attributes. The descriptor schedules the broadcast.
+
+```python
+from rxdjango.channels import ContextChannel
+from rxdjango.state import reactive
+
+class ChatChannel(ContextChannel):
+
+    notifications: int = reactive(default=0)
+    mode: str = reactive(default='view')
+    typing_users: list[int] = reactive(default_factory=list)
+    metadata: dict[str, str] = reactive(default_factory=dict)
+
+    @consumer('new.notification')
+    async def relay_notification(self, event):
+        self.notifications += 1                          # broadcasts
+        self.typing_users.append(event['user_id'])       # broadcasts (auto-proxy)
+        self.metadata['last_seen'] = event['timestamp']  # broadcasts (auto-proxy)
+
+    @consumer('batch.update')
+    async def bulk_change(self, event):
+        async with self.batch():
+            self.mode = 'edit'
+            self.notifications = 0
+            self.typing_users.clear()
+        # single websocket message with all three changes
+```
+
+Key behaviours:
+
+- **Attribute access** for both read and write. No dicts, no method calls, no `await` on writes.
+- **Class-level type annotations** are the source of truth for both Python typing and the TypeScript generator.
+- **Defaults** via `default=` or `default_factory=`, mirroring `dataclasses.field`.
+- **Auto-proxy for mutable containers** — `list`, `dict`, `set` are wrapped so in-place mutation (`.append`, `[key] = v`, `.add`) broadcasts. Nested containers proxy lazily.
+- **Explicit batching** via `async with self.batch():`. No tick coalescing.
+- **Only declared reactive fields are reactive.** Plain `self.foo = 1` on an undeclared name stays a normal attribute.
+
+## 3. Removed surface
+
+All of the following are deleted with no deprecation layer:
+
+- `ContextChannel.RuntimeState` nested class pattern.
+- `ContextChannel.runtime_state` attribute (the dict).
+- `ContextChannel.set_runtime_var(name, value)` method.
+
+## 4. Wire protocol
+
+Single-field update — **unchanged**:
+
+```json
+{"type": "runtimeVar", "var": "notifications", "value": 3}
+```
+
+Batched update — **new**:
+
+```json
+{"type": "runtimeVars", "vars": {"mode": "edit", "notifications": 0, "typing_users": []}}
+```
+
+## 5. Implementation
+
+### 5.1 New module: `rxdjango/state.py`
+
+Public:
+
+- `reactive(default=MISSING, default_factory=MISSING) -> ReactiveField`
+  Factory returning a `ReactiveField` descriptor. Exactly one of `default` / `default_factory` may be provided; both omitted is allowed only if the field is guaranteed to be set before read — otherwise reads raise `AttributeError`.
+
+Internal:
+
+- `class ReactiveField`
+  Descriptor. `__set_name__` captures the attribute name. `__get__` returns the stored value, wrapping lists/dicts/sets in the proxy types below on first access (cached); if a batch is active on the channel and this field has a pending write in the top buffer, `__get__` returns the pending value instead. `__set__` performs an equality check; if a batch is active, writes the new value into the top buffer and returns without broadcasting; otherwise stores the value on the instance and schedules a broadcast task via `asyncio.get_running_loop().create_task(...)`. If there is no running loop, `__set__` raises `RuntimeError` with a message naming the field and explaining that reactive writes must originate from an async channel handler (`@consumer`, `@action`, or a lifecycle method). No queueing, no silent fallback.
+
+- `class ReactiveList(list)`, `class ReactiveDict(dict)`, `class ReactiveSet(set)`
+  Override every mutating method (`append`, `extend`, `insert`, `remove`, `pop`, `clear`, `sort`, `reverse`, `__setitem__`, `__delitem__`, `__iadd__`, `__imul__`; `update`, `setdefault`, `popitem`; `add`, `discard`, `update`, `intersection_update`, `difference_update`, `symmetric_difference_update`). Each override calls super, then notifies the owning channel with the full new container value. Nested containers returned from `__getitem__` are wrapped lazily.
+
+- `class BatchContext`
+  Async context manager with **transactional semantics**. On enter, pushes an empty dict onto `channel._batch_stack`. While active, reactive `__set__` writes into the top buffer instead of the instance, and reactive `__get__` reads from the top buffer if the field has a pending value there. On successful exit of the outermost batch, applies every pending write to the instance's stored values and emits one `runtimeVars` message containing all changes (after final-value dedup against pre-batch values; fields whose net change is zero are omitted). On exception, the buffer is discarded — instance values are unchanged, no broadcast is emitted, the exception propagates, and a `logging.warning` is logged naming the channel class and the discarded field names. Nested `async with channel.batch():` calls push additional buffers that merge into the parent on successful inner exit; inner failures discard only the inner buffer.
+
+- Sentinel: `MISSING`.
+
+### 5.2 Changes to `rxdjango/channels.py`
+
+In `ContextChannelMeta.__new__`, after the existing setup, collect reactive fields:
+
+```python
+reactive_fields = {}
+for klass in reversed(cls.__mro__):
+    for name, value in vars(klass).items():
+        if isinstance(value, ReactiveField):
+            reactive_fields[name] = value
+            value.annotation = klass.__annotations__.get(name, Any)
+cls.__reactive_fields__ = reactive_fields
+```
+
+In `ContextChannel.__init__`, replace:
+
+```python
+self.runtime_state = self.RuntimeState() if self.RuntimeState else None
+```
+
+with per-field initialization from `default` or `default_factory`. Also initialize `self._batch_stack: list[dict] = []`.
+
+Delete:
+
+- `RuntimeState = None` class attribute.
+- `set_runtime_var` method.
+
+Add:
+
+- `def batch(self) -> BatchContext` — returns a `BatchContext` bound to this channel.
+- `async def _broadcast_field(self, name, value)` — private, sends the `runtimeVar` message.
+- `async def _broadcast_fields(self, fields: dict)` — private, sends the `runtimeVars` message.
+
+### 5.3 Changes to `rxdjango/ts/channels.py`
+
+Replace the block around line 524:
+
+```python
+if getattr(context_channel_class, 'RuntimeState', False):
+    runtime_type = f'{context_channel_class.__name__}RuntimeState'
+    types = f'{state_type}, {runtime_type}'
+else:
+    runtime_type = None
+    types = state_type
+```
+
+with:
+
+```python
+if context_channel_class.__reactive_fields__:
+    runtime_type = f'{context_channel_class.__name__}RuntimeState'
+    types = f'{state_type}, {runtime_type}'
+else:
+    runtime_type = None
+    types = state_type
+```
+
+And at line 552, replace:
+
+```python
+types = typing.get_type_hints(context_channel_class.RuntimeState)
+```
+
+with:
+
+```python
+types = {name: f.annotation
+         for name, f in context_channel_class.__reactive_fields__.items()}
+```
+
+The generated TypeScript interface must remain byte-for-byte identical to the current output for the same set of field names and types. This is enforced by a test (see 6.3).
+
+### 5.4 Changes to `rxdjango-react/src/PersistentWebsocket.ts`
+
+In the message routing `switch` (around line 148), add a case for `runtimeVars`:
+
+```ts
+case 'runtimeVars':
+  this.onRuntimeStateChange(message);
+  break;
+```
+
+### 5.5 Changes to `rxdjango-react/src/ContextChannel.ts`
+
+In `ws.onRuntimeStateChange` (around line 101), handle both message shapes:
+
+```ts
+ws.onRuntimeStateChange = (message) => {
+  const msg = message as
+    | { type: 'runtimeVar'; var: keyof Y; value: unknown }
+    | { type: 'runtimeVars'; vars: Partial<Y> };
+  if (msg.type === 'runtimeVar') {
+    this.receiveRuntimeState(msg.var, msg.value);
+  } else {
+    this.receiveRuntimeStateBatch(msg.vars);
+  }
+};
+```
+
+Add a `receiveRuntimeStateBatch(vars)` method that does a single merge-and-notify, so batched updates produce a single React re-render.
+
+## 6. Testing
+
+Three tiers. All must pass before merge.
+
+### 6.1 Unit tests — `rxdjango/tests/test_reactive.py` (new)
+
+Runs under plain `pytest rxdjango/tests/`. No Django settings, no Redis, no Mongo. Uses a dummy channel class with a mocked `_consumer.send`.
+
+Required test cases:
+
+**Field declaration and access:**
+- `reactive(default=0)` stores and returns `0` on fresh instance.
+- `reactive(default_factory=list)` returns a new list per instance (no shared state between instances).
+- Providing both `default` and `default_factory` raises `TypeError`.
+- Providing neither raises `AttributeError` on first read.
+- `__reactive_fields__` dict is populated on the class with correct names and annotations.
+- Inheritance — reactive fields from a parent channel class are inherited.
+
+**Assignment broadcasts:**
+- `channel.notifications = 5` calls `_broadcast_field('notifications', 5)` exactly once.
+- Assigning the same value (equality) does NOT broadcast.
+- Assigning to an undeclared attribute does NOT broadcast.
+
+**Container auto-proxy:**
+- `channel.items.append(x)` broadcasts the full new list.
+- `channel.items.extend([a, b])` broadcasts once with final list.
+- `channel.items.clear()` broadcasts `[]`.
+- `channel.mapping['k'] = v` broadcasts the full new dict.
+- `channel.mapping.pop('k')` broadcasts.
+- `channel.tags.add('x')` / `.discard('x')` broadcast.
+- Nested container mutation (`channel.mapping['users'].append(x)` where value is a list) broadcasts.
+- Assigning a plain `list` to a reactive list field — subsequent in-place mutations still broadcast (proxy rewraps).
+- Reading a container does NOT broadcast.
+
+**Batching:**
+- Inside `async with channel.batch():`, no individual `runtimeVar` messages are sent.
+- On exit, one `runtimeVars` message is sent containing all changed fields.
+- If a field is assigned multiple times in a batch, only the final value ships.
+- If a field is assigned its original value in a batch (net no-op), it is omitted from the batch message.
+- Nested `async with channel.batch():` collapses — only the outermost emits.
+- Empty batch (no writes) emits nothing.
+- Exception inside batch — buffer is discarded. Instance values remain at their pre-batch state. No websocket message is sent. The exception propagates. A warning is logged.
+- Inside a batch, reading a field that was just assigned in the same batch returns the pending (buffered) value, not the pre-batch value.
+- Assigning a reactive field from a sync context with no running event loop raises `RuntimeError` naming the field. No broadcast is queued or dropped silently.
+
+**Equality edge cases:**
+- Assigning `NaN` (which is not equal to itself) broadcasts every time — documented behavior.
+- Assigning an equal-but-not-identical dict (`{'a': 1}` to existing `{'a': 1}`) does NOT broadcast.
+
+### 6.2 Unit tests — `rxdjango/tests/test_ts_reactive_gen.py` (new)
+
+Validates the TypeScript generator.
+
+- Channel with reactive fields — generates a `RuntimeState` interface with correct field types.
+- Channel with no reactive fields — generates `runtimeState = null` in the output.
+- Golden test — for a representative channel, the generated TS output byte-matches an expected fixture stored in `rxdjango/tests/fixtures/expected_reactive.ts`.
+
+### 6.3 Integration test — `test_project/react_test/tests/test_runtime_state.py` (new)
+
+Runs under `python manage.py test react_test.tests.test_runtime_state` from `test_project/`. Requires Redis and Mongo.
+
+The test case exercises a realistic feature: **a typing indicator plus unread-count badge on the chat channel.** This covers single-field updates, container mutation, batching, and reconnection.
+
+Add a reactive-enabled channel in `test_project/react_test/channels.py`:
+
+```python
+class JobContextChannel(ContextChannel):
+    ...
+    typing_users: list[int] = reactive(default_factory=list)
+    unread_count: int = reactive(default=0)
+    view_mode: str = reactive(default='view')
+
+    @action
+    async def start_typing(self, user_id: int):
+        if user_id not in self.typing_users:
+            self.typing_users.append(user_id)
+
+    @action
+    async def stop_typing(self, user_id: int):
+        if user_id in self.typing_users:
+            self.typing_users.remove(user_id)
+
+    @action
+    async def mark_all_read_and_switch_to_edit(self):
+        async with self.batch():
+            self.unread_count = 0
+            self.view_mode = 'edit'
+            self.typing_users.clear()
+```
+
+Integration test scenarios (using `WebsocketCommunicator`):
+
+1. **Initial state includes reactive defaults** — Client connects, receives initial domain state, then receives exactly one `runtimeVars` message with `{typing_users: [], unread_count: 0, view_mode: 'view'}`. This message is sent immediately after initial state, before any other updates. Channels with zero reactive fields send no such message.
+
+2. **Single scalar update** — Client calls action `start_typing(user_id=1)`. Client receives a `runtimeVar` message with `var='typing_users'`, `value=[1]`.
+
+3. **Container mutation order** — Two sequential `start_typing` calls for different user IDs produce two `runtimeVar` messages, each with the correct cumulative list (`[1]`, then `[1, 2]`).
+
+4. **Removal via in-place mutation** — `stop_typing(1)` after the above produces one `runtimeVar` with `[2]`.
+
+5. **Batched update** — Client calls `mark_all_read_and_switch_to_edit`. Client receives exactly one `runtimeVars` message containing all three changed fields. No `runtimeVar` messages are sent during the batch.
+
+6. **No broadcast when value unchanged** — Calling `start_typing(1)` when user 1 is already in `typing_users` produces no websocket message (the handler's `if` guard prevents the write; the descriptor's equality check is a secondary guarantee). Assert silence for 500ms after the action returns.
+
+7. **Two clients, one channel** — Two WebSocket clients connected to the same job. Action from client A triggers `runtimeVar` delivery to both A and B.
+
+8. **Reconnection resets reactive state** — Client A connects, calls `start_typing(1)` and verifies `typing_users=[1]`. Client A disconnects. A new connection from the same user is opened. The new connection receives `typing_users=[]` (the default), not `[1]`. This validates the per-connection contract: reactive fields are ephemeral session state, they do not persist across reconnects, and each new connection starts with fresh defaults. Additionally verify: if client B is connected throughout, B's view of reactive state is unaffected by A's reconnect (B still sees whatever B's own channel instance holds).
+
+9. **TypeScript generation smoke test** — Run `makefrontend` against the test_project, assert the generated `react_test/react_test.channels.ts` includes a `JobContextChannelRuntimeState` interface with the three fields.
+
+### 6.4 Frontend tests — `rxdjango-react/src/ContextChannel.test.ts`
+
+Add to existing file:
+
+- `subscribeRuntimeState` receives a single merged update when `runtimeVars` arrives.
+- Multiple fields in one `runtimeVars` message result in exactly one listener call.
+- `runtimeVar` (single) and `runtimeVars` (batch) update the same `runtimeState` object consistently.
+
+Run: `cd rxdjango-react && yarn test --ci`.
+
+## 7. Documentation updates
+
+### 7.1 `docs/using-rxdjango.rst`
+
+Replace the entire "Runtime State" section (lines 205-258). New content:
+
+- Title: **Reactive State**
+- Declare reactive fields at the class level with `reactive(...)`.
+- Read and write as ordinary attributes.
+- In-place mutation of lists/dicts/sets is detected automatically.
+- Use `async with self.batch():` for atomic multi-field updates.
+- Frontend usage — unchanged (`runtimeState` key returned from `useChannelState`).
+
+### 7.2 `docs/context-channel.rst`
+
+Replace the "RuntimeState class" section (lines 138-143) and "runtime_state" / "set_runtime_var" subsections (lines 359-369) with a single "Reactive fields" section referencing the new API.
+
+### 7.3 `docs/api-reference.rst`
+
+Remove the `set_runtime_var(var, value)` method doc at line 107. Add a `reactive(default=..., default_factory=...)` doc entry and a `batch()` doc entry. Remove the `RuntimeState` type parameter description at line 476 and replace with a paragraph about reactive field inference.
+
+### 7.4 `CHANGELOG.md`
+
+Add under `v0.3.0` heading:
+
+```
+- BREAKING: Removed `RuntimeState` nested class, `runtime_state` dict, and
+  `set_runtime_var` method. Replaced with `reactive()` fields declared at
+  the class level. See docs/using-rxdjango.rst for migration examples.
+- Added `async with self.batch():` for atomic multi-field reactive updates,
+  transmitted as a single `runtimeVars` websocket message.
+- Added auto-proxy for `list`, `dict`, `set` reactive fields — in-place
+  mutations broadcast automatically.
+```
+
+### 7.5 `CLAUDE.md`
+
+Update any example snippets showing the old API (grep for `RuntimeState`, `runtime_state`, `set_runtime_var`).
+
+## 8. Implementation order
+
+Do it in this order. Run the relevant test suite at each checkpoint before moving on.
+
+1. `rxdjango/state.py` — `reactive`, `ReactiveField`, container proxies, `BatchContext`, `MISSING`.
+2. `rxdjango/tests/test_reactive.py` — all unit tests from 6.1. Must pass against the new module in isolation.
+3. `rxdjango/channels.py` — metaclass wiring, `__init__` changes, `batch()` method, broadcast helpers. Delete `RuntimeState`, `runtime_state`, `set_runtime_var`.
+4. `rxdjango/ts/channels.py` — generator reads `__reactive_fields__`.
+5. `rxdjango/tests/test_ts_reactive_gen.py` — golden TS output.
+6. `rxdjango-react/src/PersistentWebsocket.ts` and `ContextChannel.ts` — handle `runtimeVars`.
+7. `rxdjango-react/src/ContextChannel.test.ts` — frontend tests. Run `yarn test --ci`.
+8. Update `test_project/react_test/channels.py` with reactive fields.
+9. `test_project/react_test/tests/test_runtime_state.py` — integration tests from 6.3. Run `python manage.py test react_test.tests.test_runtime_state`.
+10. Docs — `using-rxdjango.rst`, `context-channel.rst`, `api-reference.rst`, `CHANGELOG.md`, `CLAUDE.md`.
+11. Full suite green: `pytest rxdjango/tests/`, `cd test_project && python manage.py test react_test.tests`, `cd rxdjango-react && yarn test --ci`.
+12. `flake8 --ignore=E501,W504 rxdjango`.
+13. `cd rxdjango-react && npm run lint`.
+
+## 9. Pinned decisions
+
+These three questions were weighed and closed during design review. They are **not** open for the implementer to revisit without coming back to the author.
+
+### 9.1 Reconnection behaviour — reactive state is per-connection, resets to defaults on reconnect
+
+Reactive fields are ephemeral UI coordination state (typing indicators, current view mode, transient counters). They are not domain data. Domain data lives in models, is cached in Mongo, and is re-streamed on reconnect through the existing state flow.
+
+On every new connection — initial or reconnect — the server constructs a fresh channel instance, reactive fields take their `default` / `default_factory` values, and the client receives them as a `runtimeVars` message immediately after initial state. The existing docs statement that "runtime state persists for one websocket connection" is preserved.
+
+This keeps the contract simple and the implementation small. Persistence across reconnects would require answering: where is it stored, who owns it when the instance is gone, how do two reconnecting tabs reconcile, when does it expire. None of those questions have a clear answer yet, and adding persistence later via opt-in `reactive(persist=True)` is non-breaking. Deferred to a future release.
+
+Integration test 6.3.8 enforces this behaviour.
+
+### 9.2 Exception handling in `batch()` — transactional drop
+
+If the body of `async with self.batch():` raises, the pending buffer is discarded: no values change on the instance, no websocket message is sent, the exception propagates. A `logging.warning` is emitted naming the channel class and the discarded field names, so swallowed exceptions upstream do not silently hide bugs.
+
+The alternative (flush-on-exception) would emit a partial state that no handler intended to produce, and clients would see half-written updates. That is strictly worse than drop in every scenario we could construct.
+
+To make this truly transactional, the buffer holds *pending* writes rather than applying them eagerly. Descriptor `__get__` inside an active batch returns the pending value if present, otherwise the stored value. Instance values and broadcast both commit on successful exit of the outermost batch. This matches what users expect from something called `batch()`.
+
+Unit tests in 6.1 ("Batching" and the added bullets) enforce this.
+
+### 9.3 Sync-context writes — raise `RuntimeError`, never queue or fallback
+
+`ContextChannel` lives inside an `AsyncWebsocketConsumer`. Every legitimate entry point — `connect`, `receive`, `@consumer` handlers, `@action` handlers, channel lifecycle methods — runs with a running event loop accessible via `asyncio.get_running_loop()`. Sync helper methods called from those entry points also have access to the loop.
+
+There is no legitimate code path where a reactive write originates from pure sync code with no loop. Writing reactive state from a Django signal handler is the wrong tool (use the channel layer or let the existing signal-based sync handle model-derived changes).
+
+Therefore `__set__` calls `asyncio.get_running_loop()` unconditionally and, on `RuntimeError` (no loop), re-raises with a clear message naming the field. No send queue, no deferred flush, no silent drop. One obvious failure mode with one obvious fix.
+
+Reference implementation:
+
+```python
+def __set__(self, instance, value):
+    # Batch path — buffer the write and return
+    if instance._batch_stack:
+        instance._batch_stack[-1][self.name] = value
+        return
+    # Equality check against current stored value
+    current = instance.__dict__.get(self.name, MISSING)
+    if current is not MISSING and self._equal(current, value):
+        return
+    # Require a running event loop — fail loudly if absent
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        raise RuntimeError(
+            f"Cannot set reactive field '{self.name}' outside an async context. "
+            f"Reactive writes must originate from channel handlers "
+            f"(@consumer, @action, or a lifecycle method)."
+        )
+    # Commit and schedule broadcast
+    instance.__dict__[self.name] = value
+    loop.create_task(instance._broadcast_field(self.name, value))
+```
+
+Unit tests in 6.1 (the added sync-context bullet) enforce this.
+
+## 10. Out of scope
+
+- Per-client reactive state (currently runtime state is per-connection; this stays).
+- Computed/derived reactive fields (no `@reactive_property`). Can be added later without breaking this API.
+- Persisting reactive state across reconnections beyond what the consumer already does.

--- a/docs/api-reference.rst
+++ b/docs/api-reference.rst
@@ -104,13 +104,19 @@ Base class for creating real-time channels.
 
       :param instance_id: ID of the instance to remove
 
-   .. py:method:: set_runtime_var(var, value)
-      :async:
+   .. py:method:: batch()
 
-      Set a runtime variable and push it to the connected client.
+      Returns an async context manager for atomic multi-field reactive updates.
+      All reactive field writes inside the block are buffered and emitted as a
+      single ``runtimeVars`` WebSocket message on successful exit. On exception,
+      all buffered changes are discarded (values stay at pre-batch state), a
+      warning is logged, and the exception propagates.
 
-      :param var: Variable name
-      :param value: Variable value (must be JSON-serializable)
+      .. code-block:: python
+
+          async with self.batch():
+              self.mode = 'edit'
+              self.unread_count = 0
 
    .. py:method:: send(*args, **kwargs)
       :async:
@@ -224,6 +230,46 @@ Base class for creating real-time channels.
        .. note:: The type must be declared with ``DELETE`` in ``Meta.writable``
           and the instance must belong to the channel's anchor context before
           this method is called.
+
+
+Reactive State (``rxdjango.state``)
+------------------------------------
+
+.. py:function:: reactive(default=MISSING, default_factory=MISSING)
+
+   Declare a reactive field on a :class:`ContextChannel` subclass.
+
+   Reactive fields are read and written as ordinary Python attributes.
+   Writes broadcast the new value to the connected client as a
+   ``runtimeVar`` WebSocket message. Mutable containers (``list``,
+   ``dict``, ``set``) are wrapped in transparent proxies so that in-place
+   mutations (``.append()``, ``[key] = v``, ``.add()``, etc.) also broadcast.
+
+   :param default: Default value for immutable fields (``int``, ``str``,
+                   ``bool``, ``float``, …).
+   :param default_factory: Zero-argument callable returning the default
+                           value. Use for mutable containers to avoid
+                           shared state between channel instances.
+
+   Exactly one of ``default`` / ``default_factory`` may be provided.
+   Providing neither is allowed; the field raises ``AttributeError`` on
+   read until its first write.
+
+   Reactive fields may only be written from an async context (inside a
+   ``@consumer``, ``@action``, or channel lifecycle method).
+   Writing from a sync context with no running event loop raises
+   ``RuntimeError``.
+
+   Example::
+
+       from rxdjango.channels import ContextChannel
+       from rxdjango.state import reactive
+
+       class MyChannel(ContextChannel):
+
+           count: int = reactive(default=0)
+           tags: set[str] = reactive(default_factory=set)
+           metadata: dict[str, str] = reactive(default_factory=dict)
 
 
 Decorators
@@ -473,7 +519,10 @@ ContextChannel
    WebSocket connection, authentication, state rebuilding, and RPC.
 
    :param T: Type of the root/anchor state
-   :param Y: Type of the runtime state (optional)
+   :param Y: Type of the reactive state. Inferred automatically from
+             ``reactive()`` field declarations on the Python channel class —
+             the TypeScript generator emits a ``<ChannelName>RuntimeState``
+             interface matching the Python annotations.
 
    .. js:method:: constructor(token)
 

--- a/docs/context-channel.rst
+++ b/docs/context-channel.rst
@@ -135,12 +135,24 @@ denied even if ``can_*`` would return ``True``.
 
 See :ref:`optimistic-updates` for full documentation on write operations.
 
-RuntimeState class
-==================
+Reactive fields
+===============
 
-A class named `RuntimeState`, inheriting `typing.TypedDict`, may be declared
-inside the ContextChannel subclass. It's a flat dictionary, accessible through
-`self.runtime_state`. Its values can be changed using `set_runtime_var`.
+Reactive fields are declared at the class level using ``reactive()`` from
+``rxdjango.state``. They are read and written as ordinary attributes and
+broadcast automatically to the connected client.
+
+.. code-block:: python
+
+    from rxdjango.channels import ContextChannel
+    from rxdjango.state import reactive
+
+    class MyChannel(ContextChannel):
+
+        notifications: int = reactive(default=0)
+        typing_users: list[int] = reactive(default_factory=list)
+
+See :ref:`using-rxdjango` for full documentation and examples.
 
 Methods
 =======
@@ -356,17 +368,20 @@ get_registered_channels
 
 Returns the set of all registered ContextChannel subclasses.
 
-runtime_state
--------------
+batch
+-----
 
-This property is a dictionary, containing the runtime state of the application, in case the
-`RuntimeState` class has been defined. It should be updated using `set_runtime_var` method,
-so changes are relayed to the frontend.
+Returns an async context manager for atomic multi-field reactive updates.
+All field changes inside the block are buffered and sent as a single
+``runtimeVars`` WebSocket message on exit. On exception, buffered changes
+are discarded, field values remain at their pre-batch state, and a warning
+is logged.
 
-set_runtime_var
----------------
+.. code-block:: python
 
-This sets one runtime variable, which will be relayed to the frontend and updated there.
+    async with self.batch():
+        self.mode = 'edit'
+        self.unread_count = 0
 
 Serializer Meta Options
 =======================

--- a/docs/using-rxdjango.rst
+++ b/docs/using-rxdjango.rst
@@ -202,49 +202,82 @@ The `group_add` works like in a Django Channels consumer.
 See `Channels Layers documentation <https://channels.readthedocs.io/en/stable/topics/channel_layers.html>`_
 for information on how to send messages to groups and general consumer functionality.
 
-Runtime State
--------------
+Reactive State
+--------------
 
-A `ContextChannel` can have a runtime state, which is a dictionary in the python
-class that is automatically relayed to the frontend. The runtime state persists
-for one websocket connection.
+A ``ContextChannel`` can declare reactive fields that are automatically
+synchronized to all connected clients over the WebSocket. Reactive state
+persists for one WebSocket connection and resets to its defaults on reconnect.
 
-Declare the RuntimeState class, extending TypedDict, to create a runtime state.
-The TypedDict is required so that proper typescript interfaces can be generated:
-
-.. code-block:: python
-
-    from typing import TypedDict
-    from rxdjango.channels import ContextChannel
-
-    class MyChannel(ContextChannel):
-
-        class RuntimeState(TypedDict):
-            some_number_var: int
-            some_bool_var: bool
-
-The runtime state is accessible as `self.runtime_state` in the ContextChannel.
-To change the runtime state, use the `set_runtime_var`. In the example below,
-a consumer is used to change a runtime variable.
+Declare reactive fields at the class level using ``reactive()``:
 
 .. code-block:: python
 
-    from typing import TypedDict
     from rxdjango.channels import ContextChannel
+    from rxdjango.state import reactive
 
     class MyChannel(ContextChannel):
 
-        class RuntimeState(TypedDict):
-            notifications: int
+        notifications: int = reactive(default=0)
+        mode: str = reactive(default='view')
+        typing_users: list[int] = reactive(default_factory=list)
+        metadata: dict[str, str] = reactive(default_factory=dict)
 
-        @consumer('new.notification')
-        def relay_notification(self, event):
-            notifications = self.runtime_state['notifications']
-            self.set_runtime_var('notifications', notifications + 1)
+Read and write reactive fields as ordinary attributes. Writes broadcast
+automatically to the connected client:
 
-On the frontend side, `runtimeState` is one more key returned by
-`useChannelState`. You also need to import and provide the type of
-the runtime state:
+.. code-block:: python
+
+    from rxdjango.channels import ContextChannel
+    from rxdjango.state import reactive
+    from rxdjango.actions import action
+
+    class MyChannel(ContextChannel):
+
+        notifications: int = reactive(default=0)
+        typing_users: list[int] = reactive(default_factory=list)
+
+        @action
+        async def notify(self) -> dict:
+            self.notifications += 1           # broadcasts runtimeVar
+            return {'ok': True}
+
+        @action
+        async def start_typing(self, user_id: int) -> dict:
+            if user_id not in self.typing_users:
+                self.typing_users.append(user_id)  # broadcasts via auto-proxy
+            return {'ok': True}
+
+**Mutable containers** (``list``, ``dict``, ``set``) are wrapped in
+transparent proxies on first read. In-place mutations such as
+``.append()``, ``.pop()``, ``[key] = value``, ``.add()``, and ``.clear()``
+all broadcast automatically. You do not need to reassign the field.
+
+Use ``async with self.batch():`` to send multiple field changes in a single
+WebSocket message:
+
+.. code-block:: python
+
+        @action
+        async def reset(self) -> dict:
+            async with self.batch():
+                self.notifications = 0
+                self.mode = 'view'
+                self.typing_users.clear()
+            # one runtimeVars message with all three changes
+            return {'ok': True}
+
+If an exception is raised inside ``batch()``, all buffered changes are
+discarded — no message is sent and all field values remain at their
+pre-batch state. The exception propagates normally and a warning is logged.
+
+Reactive fields may only be written from an async context (a ``@consumer``,
+``@action``, or channel lifecycle method). Writing from a sync context with
+no running event loop raises ``RuntimeError``.
+
+On the frontend side, ``runtimeState`` is one more key returned by
+``useChannelState``. The TypeScript interface is generated automatically
+from your field type annotations:
 
 .. code-block:: typescript
 

--- a/rxdjango-react/src/ContextChannel.test.ts
+++ b/rxdjango-react/src/ContextChannel.test.ts
@@ -409,4 +409,85 @@ describe('ContextChannel', () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('99999'));
     consoleSpy.mockRestore();
   });
+
+  it('subscribeRuntimeState notifies on runtimeVars batch message', () => {
+    const channel = new TestChannel('token');
+    channel.runtimeState = {};
+    channel.setArgs({ projectId: 1 });
+    channel.subscribe(jest.fn());
+    jest.runAllTimers();
+    simulateAuth(channel);
+
+    const runtimeListener = jest.fn();
+    channel.subscribeRuntimeState(runtimeListener);
+
+    simulateMessage(channel, {
+      type: 'runtimeVars',
+      vars: { mode: 'edit', count: 5 },
+    });
+
+    expect(runtimeListener).toHaveBeenCalledTimes(1);
+    expect(runtimeListener).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'edit', count: 5 })
+    );
+  });
+
+  it('runtimeVars batch message merges with existing runtimeState', () => {
+    const channel = new TestChannel('token');
+    channel.runtimeState = { existing: 'value' } as any;
+    channel.setArgs({ projectId: 1 });
+    channel.subscribe(jest.fn());
+    jest.runAllTimers();
+    simulateAuth(channel);
+
+    const runtimeListener = jest.fn();
+    channel.subscribeRuntimeState(runtimeListener);
+
+    simulateMessage(channel, {
+      type: 'runtimeVars',
+      vars: { mode: 'edit' },
+    });
+
+    expect(runtimeListener).toHaveBeenCalledWith(
+      expect.objectContaining({ existing: 'value', mode: 'edit' })
+    );
+  });
+
+  it('runtimeVars batch triggers exactly one listener call per message', () => {
+    const channel = new TestChannel('token');
+    channel.runtimeState = {};
+    channel.setArgs({ projectId: 1 });
+    channel.subscribe(jest.fn());
+    jest.runAllTimers();
+    simulateAuth(channel);
+
+    const runtimeListener = jest.fn();
+    channel.subscribeRuntimeState(runtimeListener);
+
+    simulateMessage(channel, {
+      type: 'runtimeVars',
+      vars: { a: 1, b: 2, c: 3 },
+    });
+
+    // Three fields in one message must produce exactly one listener call.
+    expect(runtimeListener).toHaveBeenCalledTimes(1);
+  });
+
+  it('runtimeVar and runtimeVars both update the same runtimeState object', () => {
+    const channel = new TestChannel('token');
+    channel.runtimeState = {};
+    channel.setArgs({ projectId: 1 });
+    channel.subscribe(jest.fn());
+    jest.runAllTimers();
+    simulateAuth(channel);
+
+    const runtimeListener = jest.fn();
+    channel.subscribeRuntimeState(runtimeListener);
+
+    simulateMessage(channel, { type: 'runtimeVar', var: 'mode', value: 'edit' });
+    simulateMessage(channel, { type: 'runtimeVars', vars: { count: 3 } });
+
+    const finalState = runtimeListener.mock.calls[1][0];
+    expect(finalState).toMatchObject({ mode: 'edit', count: 3 });
+  });
 });

--- a/rxdjango-react/src/ContextChannel.ts
+++ b/rxdjango-react/src/ContextChannel.ts
@@ -99,10 +99,14 @@ abstract class ContextChannel<T, Y=unknown> {
     };
 
     ws.onRuntimeStateChange = (message) => {
-      const msg = message as { type: 'runtimeVar'; var: keyof Y; value: unknown };
-      const runtimeVar = msg.var;
-      const value = msg.value;
-      this.receiveRuntimeState(runtimeVar, value);
+      const msg = message as
+        | { type: 'runtimeVar'; var: keyof Y; value: unknown }
+        | { type: 'runtimeVars'; vars: Partial<Y> };
+      if (msg.type === 'runtimeVar') {
+        this.receiveRuntimeState(msg.var, msg.value);
+      } else {
+        this.receiveRuntimeStateBatch(msg.vars);
+      }
     };
 
     ws.onAnchorPrepend = (anchorId) => {
@@ -141,6 +145,11 @@ abstract class ContextChannel<T, Y=unknown> {
 
   private receiveRuntimeState(runtimeVar: keyof Y, value: unknown) {
     this.runtimeState = { ...this.runtimeState, [runtimeVar]: value } as Y;
+    this.notifyRuntimeState();
+  }
+
+  private receiveRuntimeStateBatch(vars: Partial<Y>) {
+    this.runtimeState = { ...this.runtimeState, ...vars } as Y;
     this.notifyRuntimeState();
   }
 

--- a/rxdjango-react/src/PersistentWebsocket.test.ts
+++ b/rxdjango-react/src/PersistentWebsocket.test.ts
@@ -167,6 +167,20 @@ describe('PersistentWebSocket', () => {
     expect(onRuntime).toHaveBeenCalledWith({ type: 'runtimeVar', var: 'mode', value: 'edit' });
   });
 
+  it('routes runtimeVars batch messages', () => {
+    const ws = createWs();
+    const onRuntime = jest.fn();
+    ws.onRuntimeStateChange = onRuntime;
+    ws.connect();
+    jest.runAllTimers();
+
+    const socket = getSocket(ws);
+    socket.onmessage!({ data: JSON.stringify({ type: 'auth', statusCode: 200 }) });
+    socket.onmessage!({ data: JSON.stringify({ type: 'runtimeVars', vars: { mode: 'edit', count: 3 } }) });
+
+    expect(onRuntime).toHaveBeenCalledWith({ type: 'runtimeVars', vars: { mode: 'edit', count: 3 } });
+  });
+
   it('routes initialAnchors message', () => {
     const ws = createWs();
     const onAnchors = jest.fn();

--- a/rxdjango-react/src/PersistentWebsocket.ts
+++ b/rxdjango-react/src/PersistentWebsocket.ts
@@ -146,6 +146,7 @@ export default class PersistentWebSocket {
           break;
 
         case 'runtimeVar':
+        case 'runtimeVars':
           this.onRuntimeStateChange(message);
           break;
 

--- a/rxdjango/channels.py
+++ b/rxdjango/channels.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import AbstractBaseUser
 from rest_framework import serializers
 
 from .consumers import StateConsumer, get_consumer_methods
+from .state import ReactiveField, BatchContext, MISSING
 from .state_model import StateModel
 from .state_loader import StateLoader
 from .websocket_router import WebsocketRouter
@@ -121,6 +122,19 @@ class ContextChannelMeta(type):
         new_class._anchor_events_channel = f'{new_class.__name__}-anchor-events'
         new_class._consumer_methods = get_consumer_methods(new_class)
 
+        # Collect reactive fields declared on this class and its bases.
+        reactive_fields: dict[str, ReactiveField] = {}
+        for klass in reversed(new_class.__mro__):
+            for attr_name, attr_val in vars(klass).items():
+                if isinstance(attr_val, ReactiveField):
+                    # Capture annotation if not already set by __set_name__
+                    if not attr_val.name:
+                        attr_val.name = attr_name
+                    annotation = klass.__annotations__.get(attr_name)
+                    attr_val.annotation = annotation
+                    reactive_fields[attr_name] = attr_val
+        new_class.__reactive_fields__ = reactive_fields
+
         # Register this channel class for cache expiry scanning
         ContextChannel._registry.add(new_class)
 
@@ -140,7 +154,7 @@ class ContextChannel(metaclass=ContextChannelMeta):
     class Meta:
         abstract = True
 
-    RuntimeState = None
+    __reactive_fields__: ClassVar[dict[str, ReactiveField]] = {}
     _registry: ClassVar[set[type]] = set()
 
     @classmethod
@@ -161,9 +175,15 @@ class ContextChannel(metaclass=ContextChannelMeta):
         self.user = user
         self.user_id = user.id
         self._consumer = None  # will be set by consumer
-        self.runtime_state = self.RuntimeState() if self.RuntimeState else None
+        self._batch_stack: list[dict] = []
         self.anchor_ids: list[int] = []
         self.anchor_index: set[int] = set()
+
+        # Initialise reactive fields from their defaults.
+        for field_name, field in self.__reactive_fields__.items():
+            initial = field.initial_value()
+            if initial is not MISSING:
+                self.__dict__[field_name] = initial
 
     async def send(self, *args: Any, **kwargs: Any) -> None:
         """A proxy method to self._consumer.send"""
@@ -219,11 +239,30 @@ class ContextChannel(metaclass=ContextChannelMeta):
                     data = json_dumps(instances)
                     await self.send(text_data=data)
 
-    async def set_runtime_var(self, var: str, value: Any) -> None:
-        self.runtime_state[var] = value
-        payload = {'type': 'runtimeVar', 'var': var, 'value': value}
-        payload = json.dumps(payload)
+    async def _broadcast_field(self, name: str, value: Any) -> None:
+        """Send a single reactive field update to the connected client."""
+        payload = json.dumps({'type': 'runtimeVar', 'var': name, 'value': value}, default=str)
         await self.send(text_data=payload)
+
+    async def _broadcast_fields(self, fields: dict[str, Any]) -> None:
+        """Send a batched reactive field update to the connected client."""
+        payload = json.dumps({'type': 'runtimeVars', 'vars': fields}, default=str)
+        await self.send(text_data=payload)
+
+    def batch(self) -> BatchContext:
+        """Return an async context manager for atomic multi-field reactive updates.
+
+        Changes made inside the block are buffered and sent as a single
+        ``runtimeVars`` websocket message on exit. On exception, all
+        buffered changes are discarded and a warning is logged.
+
+        Usage::
+
+            async with self.batch():
+                self.mode = 'edit'
+                self.unread_count = 0
+        """
+        return BatchContext(self)
 
     @database_sync_to_async
     def serialize_instance(self, instance: Model, tstamp: float = 0) -> dict[str, Any]:

--- a/rxdjango/consumers.py
+++ b/rxdjango/consumers.py
@@ -53,8 +53,11 @@ Outgoing messages (server -> client)::
     {"type": "writeResponse", "writeId": <id>, "success": true}
     {"type": "writeResponse", "writeId": <id>, "success": false, "error": {"code": 403, "message": "..."}}
 
-    # Runtime state change
+    # Runtime state change (single field)
     {"type": "runtimeVar", "var": "varName", "value": ...}
+
+    # Runtime state change (batched, also sent on initial connect)
+    {"type": "runtimeVars", "vars": {"field1": ..., "field2": ...}}
 
     # System/maintenance broadcasts
     {"type": "system", "source": "system", "message": "..."}
@@ -225,6 +228,19 @@ class StateConsumer(AsyncWebsocketConsumer):
 
         for anchor_id in self.anchor_ids:
             await self._load_state(anchor_id, tstamp)
+
+        # Send initial reactive field values to the client.
+        if self.channel.__reactive_fields__:
+            initial = {
+                name: self.channel.__dict__.get(name)
+                for name in self.channel.__reactive_fields__
+                if name in self.channel.__dict__
+            }
+            if initial:
+                import json as _json
+                await self.send(text_data=_json.dumps(
+                    {'type': 'runtimeVars', 'vars': initial}, default=str
+                ))
 
     async def instances_list_add(self, event: dict[str, Any]) -> None:
         """Handle channel layer event for adding an instance to a many=True list.

--- a/rxdjango/state.py
+++ b/rxdjango/state.py
@@ -1,0 +1,577 @@
+"""Reactive state for ContextChannel.
+
+This module provides the :func:`reactive` field factory and supporting
+machinery so that subclasses of :class:`rxdjango.channels.ContextChannel`
+can declare reactive fields that are automatically synchronized with
+connected clients over the WebSocket.
+
+Usage::
+
+    from rxdjango.channels import ContextChannel
+    from rxdjango.state import reactive
+
+    class ChatChannel(ContextChannel):
+
+        notifications: int = reactive(default=0)
+        mode: str = reactive(default='view')
+        typing_users: list[int] = reactive(default_factory=list)
+
+        async def some_handler(self, event):
+            self.notifications += 1                  # broadcasts
+            self.typing_users.append(event['uid'])   # broadcasts (auto-proxy)
+
+            async with self.batch():
+                self.mode = 'edit'
+                self.notifications = 0
+            # single websocket message with both changes
+
+Design decisions pinned in ``Runtime-Refactor-FDD.md``:
+
+* Reactive state is per-connection; it does not persist across reconnects.
+* Writes must originate from an async context. Writing from a sync context
+  (no running event loop) raises :class:`RuntimeError`.
+* ``batch()`` is transactional: on exception the buffered writes are
+  dropped, no broadcast is emitted, a warning is logged, the exception
+  propagates.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+
+class _Missing:
+    """Sentinel for "no default provided"."""
+
+    _instance: '_Missing | None' = None
+
+    def __new__(cls) -> '_Missing':
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def __repr__(self) -> str:
+        return 'MISSING'
+
+    def __bool__(self) -> bool:
+        return False
+
+
+MISSING: Any = _Missing()
+
+
+def reactive(default: Any = MISSING,
+             default_factory: Any = MISSING) -> 'ReactiveField':
+    """Declare a reactive field on a :class:`ContextChannel` subclass.
+
+    Reactive fields are read and written as ordinary attributes. Writes
+    are synchronized to all connected clients over the WebSocket as
+    ``runtimeVar`` (single write) or ``runtimeVars`` (batched) messages.
+
+    Parameters
+    ----------
+    default
+        Default value for the field. Used for immutables (ints, strings,
+        tuples, frozen containers).
+    default_factory
+        Zero-argument callable that returns the default value. Used for
+        mutables (lists, dicts, sets) to avoid shared state between
+        channel instances.
+
+    Exactly one of ``default`` / ``default_factory`` may be provided.
+    Providing neither is allowed; the field will raise
+    :class:`AttributeError` on read until the first write.
+
+    Returns
+    -------
+    ReactiveField
+        A descriptor that should be assigned at class body level.
+    """
+    if default is not MISSING and default_factory is not MISSING:
+        raise TypeError(
+            "reactive() accepts at most one of 'default' or 'default_factory'"
+        )
+    return ReactiveField(default=default, default_factory=default_factory)
+
+
+class ReactiveField:
+    """Descriptor that intercepts reads/writes of a reactive field.
+
+    Do not instantiate directly; use :func:`reactive`.
+    """
+
+    __slots__ = ('name', 'default', 'default_factory', 'annotation')
+
+    def __init__(self, default: Any = MISSING,
+                 default_factory: Any = MISSING) -> None:
+        self.name: str = ''
+        self.default = default
+        self.default_factory = default_factory
+        self.annotation: Any = Any
+
+    def __set_name__(self, owner: type, name: str) -> None:
+        self.name = name
+
+    def initial_value(self) -> Any:
+        """Return the initial value for a new channel instance."""
+        if self.default_factory is not MISSING:
+            return self.default_factory()
+        if self.default is not MISSING:
+            return self.default
+        return MISSING
+
+    # Descriptor protocol ---------------------------------------------------
+
+    def __get__(self, instance: Any, owner: type | None = None) -> Any:
+        if instance is None:
+            return self
+
+        batch_stack = getattr(instance, '_batch_stack', None)
+        store = instance.__dict__
+
+        # Inside a batch, a pending write takes precedence over the
+        # stored value. Containers are copied into the top frame on
+        # first access so mutations don't leak into the committed
+        # state until the batch exits successfully.
+        if batch_stack:
+            # Find a pending value in any active frame (innermost wins)
+            for frame in reversed(batch_stack):
+                if self.name in frame:
+                    return self._wrap_container(instance, frame[self.name])
+
+            # No pending value yet — if the stored value is a mutable
+            # container, clone it into the top frame so further
+            # in-place mutations are transactional.
+            if self.name in store:
+                value = store[self.name]
+                if isinstance(value, (list, dict, set)):
+                    clone = type(value)(value)
+                    batch_stack[-1][self.name] = clone
+                    return self._wrap_container(instance, clone)
+                return self._wrap_container(instance, value)
+
+            raise AttributeError(
+                f"Reactive field {self.name!r} has no value yet and no "
+                f"default. Either set a default / default_factory in "
+                f"reactive() or assign a value before reading."
+            )
+
+        if self.name not in store:
+            raise AttributeError(
+                f"Reactive field {self.name!r} has no value yet and no "
+                f"default. Either set a default / default_factory in "
+                f"reactive() or assign a value before reading."
+            )
+        return self._wrap_container(instance, store[self.name])
+
+    def __set__(self, instance: Any, value: Any) -> None:
+        # Unwrap reactive containers before storing, so we never end
+        # up with proxies-of-proxies inside buffers or on instance.
+        value = _unwrap(value)
+
+        batch_stack = getattr(instance, '_batch_stack', None)
+        if batch_stack:
+            # Inside a batch — buffer the pending write. No equality
+            # check vs stored value here; the outer batch handles
+            # net-zero deduplication on commit.
+            batch_stack[-1][self.name] = value
+            return
+
+        # Normal write path — equality check against stored value
+        current = instance.__dict__.get(self.name, MISSING)
+        if current is not MISSING and _equal(current, value):
+            return
+
+        # Reactive writes must originate from an async context. Fail
+        # loudly rather than queuing or silently dropping.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            raise RuntimeError(
+                f"Cannot set reactive field {self.name!r} outside an "
+                f"async context. Reactive writes must originate from "
+                f"a channel handler (@consumer, @action, or a channel "
+                f"lifecycle method)."
+            )
+
+        instance.__dict__[self.name] = value
+        loop.create_task(instance._broadcast_field(self.name, value))
+
+    # Helpers ---------------------------------------------------------------
+
+    def _wrap_container(self, instance: Any, value: Any) -> Any:
+        """Wrap lists/dicts/sets in reactive proxies on read.
+
+        Caching behaviour: outside a batch, we cache the proxy back
+        into the instance dict so subsequent reads return the same
+        object and mutation methods stay bound to it. Inside a batch,
+        we cache into the top batch frame — the stored instance value
+        is untouched until the batch commits.
+        """
+        if isinstance(value, (ReactiveList, ReactiveDict, ReactiveSet)):
+            return value
+
+        batch_stack = getattr(instance, '_batch_stack', None)
+        target: dict[str, Any]
+        if batch_stack and self.name in batch_stack[-1]:
+            target = batch_stack[-1]
+        else:
+            target = instance.__dict__
+
+        if isinstance(value, list):
+            wrapped = ReactiveList(value, instance, self.name)
+        elif isinstance(value, dict):
+            wrapped = ReactiveDict(value, instance, self.name)
+        elif isinstance(value, set):
+            wrapped = ReactiveSet(value, instance, self.name)
+        else:
+            return value
+
+        target[self.name] = wrapped
+        return wrapped
+
+
+def _equal(a: Any, b: Any) -> bool:
+    """Equality check that treats reactive proxies as their underlying type.
+
+    Python's list/dict/set ``==`` already compares by value against our
+    subclasses, so this is mostly a thin wrapper. We keep it in one
+    place so future tweaks (e.g. special-casing NaN) live here.
+    """
+    try:
+        return a == b
+    except Exception:  # pragma: no cover - defensive
+        return False
+
+
+def _unwrap(value: Any) -> Any:
+    """Return the underlying plain container for a reactive proxy.
+
+    Proxies are transient views bound to a specific owner/field. When a
+    value is reassigned between fields or instances, we strip the proxy
+    so the new owner can wrap it fresh on next read.
+    """
+    if isinstance(value, ReactiveList):
+        return list(value)
+    if isinstance(value, ReactiveDict):
+        return dict(value)
+    if isinstance(value, ReactiveSet):
+        return set(value)
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Reactive container proxies
+# ---------------------------------------------------------------------------
+
+
+def _notify(owner: Any, field_name: str, container: Any) -> None:
+    """Notify the owning channel that a reactive container mutated.
+
+    Outside a batch: schedule a broadcast with a snapshot of the
+    container (so later mutations don't retroactively change the
+    broadcast payload).
+
+    Inside a batch: the container IS the batch buffer value (cloned
+    into the buffer on first read). The mutation already updated it
+    in place; commit will pick it up on batch exit. No action needed
+    here — but we do verify the buffer still references this proxy.
+    """
+    batch_stack = getattr(owner, '_batch_stack', None)
+    if batch_stack:
+        # Make sure the top frame has a reference to the proxy so
+        # commit sees the mutated value. If it doesn't (e.g. because
+        # the mutation happened before any batch read of this field),
+        # record it now.
+        if field_name not in batch_stack[-1]:
+            batch_stack[-1][field_name] = container
+        return
+
+    snapshot = _unwrap(container)
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        raise RuntimeError(
+            f"Cannot mutate reactive container {field_name!r} outside an "
+            f"async context. Reactive writes must originate from a channel "
+            f"handler (@consumer, @action, or a channel lifecycle method)."
+        )
+
+    loop.create_task(owner._broadcast_field(field_name, snapshot))
+
+
+class ReactiveList(list):
+    """A ``list`` that broadcasts when mutated in place."""
+
+    __slots__ = ('_rx_owner', '_rx_field')
+
+    def __init__(self, initial: Any, owner: Any, field_name: str) -> None:
+        super().__init__(initial)
+        self._rx_owner = owner
+        self._rx_field = field_name
+
+    # Mutators
+    def append(self, value: Any) -> None:
+        super().append(value)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def extend(self, iterable: Any) -> None:
+        super().extend(iterable)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def insert(self, index: int, value: Any) -> None:
+        super().insert(index, value)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def remove(self, value: Any) -> None:
+        super().remove(value)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def pop(self, index: int = -1) -> Any:
+        result = super().pop(index)
+        _notify(self._rx_owner, self._rx_field, self)
+        return result
+
+    def clear(self) -> None:
+        if not len(self):
+            return
+        super().clear()
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def sort(self, *args: Any, **kwargs: Any) -> None:
+        super().sort(*args, **kwargs)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def reverse(self) -> None:
+        super().reverse()
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def __setitem__(self, index: Any, value: Any) -> None:
+        super().__setitem__(index, value)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def __delitem__(self, index: Any) -> None:
+        super().__delitem__(index)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def __iadd__(self, other: Any) -> 'ReactiveList':
+        result = super().__iadd__(other)
+        _notify(self._rx_owner, self._rx_field, self)
+        return result
+
+    def __imul__(self, n: int) -> 'ReactiveList':
+        result = super().__imul__(n)
+        _notify(self._rx_owner, self._rx_field, self)
+        return result
+
+
+class ReactiveDict(dict):
+    """A ``dict`` that broadcasts when mutated in place."""
+
+    __slots__ = ('_rx_owner', '_rx_field')
+
+    def __init__(self, initial: Any, owner: Any, field_name: str) -> None:
+        super().__init__(initial)
+        self._rx_owner = owner
+        self._rx_field = field_name
+
+    def __setitem__(self, key: Any, value: Any) -> None:
+        super().__setitem__(key, value)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def __delitem__(self, key: Any) -> None:
+        super().__delitem__(key)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        super().update(*args, **kwargs)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def setdefault(self, key: Any, default: Any = None) -> Any:
+        had_key = key in self
+        result = super().setdefault(key, default)
+        if not had_key:
+            _notify(self._rx_owner, self._rx_field, self)
+        return result
+
+    def pop(self, key: Any, *args: Any) -> Any:
+        had_key = key in self
+        result = super().pop(key, *args)
+        if had_key:
+            _notify(self._rx_owner, self._rx_field, self)
+        return result
+
+    def popitem(self) -> Any:
+        result = super().popitem()
+        _notify(self._rx_owner, self._rx_field, self)
+        return result
+
+    def clear(self) -> None:
+        if not len(self):
+            return
+        super().clear()
+        _notify(self._rx_owner, self._rx_field, self)
+
+
+class ReactiveSet(set):
+    """A ``set`` that broadcasts when mutated in place."""
+
+    __slots__ = ('_rx_owner', '_rx_field')
+
+    def __init__(self, initial: Any, owner: Any, field_name: str) -> None:
+        super().__init__(initial)
+        self._rx_owner = owner
+        self._rx_field = field_name
+
+    def add(self, value: Any) -> None:
+        had = value in self
+        super().add(value)
+        if not had:
+            _notify(self._rx_owner, self._rx_field, self)
+
+    def discard(self, value: Any) -> None:
+        had = value in self
+        super().discard(value)
+        if had:
+            _notify(self._rx_owner, self._rx_field, self)
+
+    def remove(self, value: Any) -> None:
+        super().remove(value)
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def pop(self) -> Any:
+        result = super().pop()
+        _notify(self._rx_owner, self._rx_field, self)
+        return result
+
+    def clear(self) -> None:
+        if not len(self):
+            return
+        super().clear()
+        _notify(self._rx_owner, self._rx_field, self)
+
+    def update(self, *others: Any) -> None:
+        before = len(self)
+        super().update(*others)
+        if len(self) != before:
+            _notify(self._rx_owner, self._rx_field, self)
+
+    def intersection_update(self, *others: Any) -> None:
+        before = frozenset(self)
+        super().intersection_update(*others)
+        if frozenset(self) != before:
+            _notify(self._rx_owner, self._rx_field, self)
+
+    def difference_update(self, *others: Any) -> None:
+        before = frozenset(self)
+        super().difference_update(*others)
+        if frozenset(self) != before:
+            _notify(self._rx_owner, self._rx_field, self)
+
+    def symmetric_difference_update(self, other: Any) -> None:
+        before = frozenset(self)
+        super().symmetric_difference_update(other)
+        if frozenset(self) != before:
+            _notify(self._rx_owner, self._rx_field, self)
+
+
+# ---------------------------------------------------------------------------
+# Batch context
+# ---------------------------------------------------------------------------
+
+
+class BatchContext:
+    """Async context manager for atomic multi-field reactive updates.
+
+    Usage::
+
+        async with channel.batch():
+            channel.foo = 1
+            channel.bar = 2
+        # one websocket message with both changes
+
+    Semantics:
+
+    * On enter, push an empty dict onto ``channel._batch_stack``.
+    * Reactive writes inside the block are buffered on the top frame
+      instead of being broadcast individually.
+    * Reactive reads inside the block see pending values first.
+    * On successful exit of the outermost batch, buffered writes commit
+      to the instance and a single ``runtimeVars`` message is sent.
+      Fields whose net change equals the pre-batch value are omitted.
+    * On exception, the buffer is discarded — values remain at their
+      pre-batch state, no broadcast is emitted, a warning is logged,
+      and the exception propagates.
+    * Nested batches merge into the parent buffer on successful inner
+      exit; inner failures discard only the inner frame.
+    """
+
+    __slots__ = ('_channel',)
+
+    def __init__(self, channel: Any) -> None:
+        self._channel = channel
+
+    async def __aenter__(self) -> 'BatchContext':
+        if not hasattr(self._channel, '_batch_stack'):
+            self._channel._batch_stack = []
+        self._channel._batch_stack.append({})
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any,
+                        exc_tb: Any) -> None:
+        stack = self._channel._batch_stack
+        frame = stack.pop()
+
+        if exc_type is not None:
+            # Discard this frame entirely. If it was the outermost,
+            # nothing committed. If we're nested, the parent frame
+            # is untouched so its pending writes are preserved.
+            if frame:
+                logger.warning(
+                    "Discarding %d buffered reactive write(s) on %s "
+                    "due to exception in batch(): %s",
+                    len(frame),
+                    type(self._channel).__name__,
+                    sorted(frame.keys()),
+                )
+            return
+
+        if not frame:
+            return
+
+        if stack:
+            # Nested batch — merge into the parent frame.
+            stack[-1].update(frame)
+            return
+
+        # Outermost batch — commit to instance and broadcast.
+        changed: dict[str, Any] = {}
+        for name, value in frame.items():
+            current = self._channel.__dict__.get(name, MISSING)
+            # Unwrap proxies before comparing and storing so the
+            # committed value is a plain container.
+            plain = _unwrap(value)
+            if current is not MISSING and _equal(current, plain):
+                continue
+            self._channel.__dict__[name] = plain
+            changed[name] = plain
+
+        if not changed:
+            return
+
+        await self._channel._broadcast_fields(changed)
+
+
+__all__ = [
+    'reactive',
+    'ReactiveField',
+    'ReactiveList',
+    'ReactiveDict',
+    'ReactiveSet',
+    'BatchContext',
+    'MISSING',
+]

--- a/rxdjango/tests/test_reactive.py
+++ b/rxdjango/tests/test_reactive.py
@@ -1,0 +1,544 @@
+"""Unit tests for rxdjango.state (reactive fields, containers, batching).
+
+These tests exercise the reactive state machinery in isolation, without
+any Django, Redis, Mongo, or real websocket dependencies. We use a
+stub "channel" class that records broadcast calls.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import pytest
+
+from rxdjango.state import (
+    BatchContext,
+    MISSING,
+    ReactiveField,
+    reactive,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test fixtures — a minimal channel-like host for ReactiveField
+# ---------------------------------------------------------------------------
+
+
+class StubChannel:
+    """Mimics the subset of ContextChannel that ReactiveField talks to."""
+
+    def __init__(self) -> None:
+        self._batch_stack: list[dict] = []
+        self.single_broadcasts: list[tuple[str, Any]] = []
+        self.batch_broadcasts: list[dict] = []
+
+    async def _broadcast_field(self, name: str, value: Any) -> None:
+        self.single_broadcasts.append((name, value))
+
+    async def _broadcast_fields(self, fields: dict[str, Any]) -> None:
+        self.batch_broadcasts.append(fields)
+
+    def batch(self) -> BatchContext:
+        return BatchContext(self)
+
+
+def make_channel_with_fields(**fields: ReactiveField) -> type:
+    """Build a StubChannel subclass that has the given reactive fields.
+
+    Mirrors what ContextChannelMeta would do minus the Django machinery.
+    """
+    cls = type('ReactiveStub', (StubChannel,), dict(fields))
+    reactive_fields = {}
+    for name, value in fields.items():
+        if isinstance(value, ReactiveField):
+            # Simulate __set_name__ / metaclass annotation capture
+            value.__set_name__(cls, name)
+            reactive_fields[name] = value
+    cls.__reactive_fields__ = reactive_fields
+    return cls
+
+
+async def drain() -> None:
+    """Let scheduled broadcast tasks run to completion."""
+    # One pass gives the event loop a chance to run create_task'd coros.
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+# ---------------------------------------------------------------------------
+# Field declaration and defaults
+# ---------------------------------------------------------------------------
+
+
+class TestReactiveFactory:
+    def test_default_value(self) -> None:
+        Cls = make_channel_with_fields(n=reactive(default=0))
+        ch = Cls()
+        # Populate initial value as ContextChannel.__init__ would
+        ch.__dict__['n'] = Cls.__reactive_fields__['n'].initial_value()
+        assert ch.n == 0
+
+    def test_default_factory_returns_new_instance(self) -> None:
+        Cls = make_channel_with_fields(items=reactive(default_factory=list))
+        a = Cls()
+        b = Cls()
+        a.__dict__['items'] = Cls.__reactive_fields__['items'].initial_value()
+        b.__dict__['items'] = Cls.__reactive_fields__['items'].initial_value()
+        assert a.items == []
+        assert b.items == []
+        assert a.items is not b.items, "default_factory must not share state"
+
+    def test_both_default_and_factory_raises(self) -> None:
+        with pytest.raises(TypeError, match="at most one of"):
+            reactive(default=[], default_factory=list)
+
+    def test_neither_default_nor_factory_raises_on_read(self) -> None:
+        Cls = make_channel_with_fields(x=reactive())
+        ch = Cls()
+        # No initial value assigned
+        with pytest.raises(AttributeError, match="no value yet"):
+            _ = ch.x
+
+    def test_initial_value_missing_when_no_default(self) -> None:
+        field = reactive()
+        assert field.initial_value() is MISSING
+
+
+# ---------------------------------------------------------------------------
+# Assignment broadcasts
+# ---------------------------------------------------------------------------
+
+
+class TestAssignment:
+    def setup_method(self) -> None:
+        self.Cls = make_channel_with_fields(
+            n=reactive(default=0),
+            s=reactive(default='view'),
+        )
+
+    def _fresh(self) -> StubChannel:
+        ch = self.Cls()
+        ch.__dict__['n'] = 0
+        ch.__dict__['s'] = 'view'
+        return ch
+
+    def test_set_broadcasts_once(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.n = 5
+            await drain()
+            assert ch.single_broadcasts == [('n', 5)]
+            assert ch.batch_broadcasts == []
+        asyncio.run(go())
+
+    def test_same_value_does_not_broadcast(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.n = 0  # same as default
+            await drain()
+            assert ch.single_broadcasts == []
+        asyncio.run(go())
+
+    def test_undeclared_attribute_is_plain(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.not_reactive = 99
+            await drain()
+            assert ch.single_broadcasts == []
+            assert ch.not_reactive == 99
+        asyncio.run(go())
+
+    def test_sync_context_raises(self) -> None:
+        ch = self._fresh()
+        # No running loop here
+        with pytest.raises(RuntimeError, match="outside an async context"):
+            ch.n = 7
+
+    def test_write_then_read_returns_new_value(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.n = 42
+            await drain()
+            assert ch.n == 42
+        asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# Reactive list
+# ---------------------------------------------------------------------------
+
+
+class TestReactiveList:
+    def setup_method(self) -> None:
+        self.Cls = make_channel_with_fields(
+            items=reactive(default_factory=list),
+        )
+
+    def _fresh(self) -> StubChannel:
+        ch = self.Cls()
+        ch.__dict__['items'] = []
+        return ch
+
+    def test_append_broadcasts(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.items.append(1)
+            await drain()
+            assert ch.single_broadcasts == [('items', [1])]
+        asyncio.run(go())
+
+    def test_extend_broadcasts_once(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.items.extend([1, 2, 3])
+            await drain()
+            assert ch.single_broadcasts == [('items', [1, 2, 3])]
+        asyncio.run(go())
+
+    def test_clear_broadcasts_when_non_empty(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.items.extend([1, 2])
+            await drain()
+            ch.single_broadcasts.clear()
+            ch.items.clear()
+            await drain()
+            assert ch.single_broadcasts == [('items', [])]
+        asyncio.run(go())
+
+    def test_clear_on_empty_skips(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.items.clear()
+            await drain()
+            assert ch.single_broadcasts == []
+        asyncio.run(go())
+
+    def test_multiple_ops_each_broadcast(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.items.append(1)
+            ch.items.append(2)
+            ch.items.pop()
+            await drain()
+            assert ch.single_broadcasts == [
+                ('items', [1]),
+                ('items', [1, 2]),
+                ('items', [1]),
+            ]
+        asyncio.run(go())
+
+    def test_read_does_not_broadcast(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.items.append(1)
+            await drain()
+            ch.single_broadcasts.clear()
+            _ = list(ch.items)  # pure read
+            _ = len(ch.items)
+            await drain()
+            assert ch.single_broadcasts == []
+        asyncio.run(go())
+
+    def test_assigned_plain_list_then_mutation_broadcasts(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.items = [1, 2]  # fresh assignment
+            await drain()
+            ch.single_broadcasts.clear()
+            ch.items.append(3)  # proxy rewraps on access
+            await drain()
+            assert ch.single_broadcasts == [('items', [1, 2, 3])]
+        asyncio.run(go())
+
+    def test_setitem_broadcasts(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.items.extend([1, 2, 3])
+            await drain()
+            ch.single_broadcasts.clear()
+            ch.items[0] = 99
+            await drain()
+            assert ch.single_broadcasts == [('items', [99, 2, 3])]
+        asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# Reactive dict
+# ---------------------------------------------------------------------------
+
+
+class TestReactiveDict:
+    def setup_method(self) -> None:
+        self.Cls = make_channel_with_fields(
+            mapping=reactive(default_factory=dict),
+        )
+
+    def _fresh(self) -> StubChannel:
+        ch = self.Cls()
+        ch.__dict__['mapping'] = {}
+        return ch
+
+    def test_setitem_broadcasts(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.mapping['k'] = 'v'
+            await drain()
+            assert ch.single_broadcasts == [('mapping', {'k': 'v'})]
+        asyncio.run(go())
+
+    def test_pop_broadcasts_when_key_exists(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.mapping['k'] = 'v'
+            await drain()
+            ch.single_broadcasts.clear()
+            ch.mapping.pop('k')
+            await drain()
+            assert ch.single_broadcasts == [('mapping', {})]
+        asyncio.run(go())
+
+    def test_pop_missing_key_with_default_skips(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.mapping.pop('nope', None)
+            await drain()
+            assert ch.single_broadcasts == []
+        asyncio.run(go())
+
+    def test_update_broadcasts(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.mapping.update({'a': 1, 'b': 2})
+            await drain()
+            assert ch.single_broadcasts == [('mapping', {'a': 1, 'b': 2})]
+        asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# Reactive set
+# ---------------------------------------------------------------------------
+
+
+class TestReactiveSet:
+    def setup_method(self) -> None:
+        self.Cls = make_channel_with_fields(
+            tags=reactive(default_factory=set),
+        )
+
+    def _fresh(self) -> StubChannel:
+        ch = self.Cls()
+        ch.__dict__['tags'] = set()
+        return ch
+
+    def test_add_broadcasts(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.tags.add('a')
+            await drain()
+            assert ch.single_broadcasts == [('tags', {'a'})]
+        asyncio.run(go())
+
+    def test_add_existing_skips(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.tags.add('a')
+            await drain()
+            ch.single_broadcasts.clear()
+            ch.tags.add('a')
+            await drain()
+            assert ch.single_broadcasts == []
+        asyncio.run(go())
+
+    def test_discard_missing_skips(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            ch.tags.discard('nope')
+            await drain()
+            assert ch.single_broadcasts == []
+        asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# Batching
+# ---------------------------------------------------------------------------
+
+
+class TestBatching:
+    def setup_method(self) -> None:
+        self.Cls = make_channel_with_fields(
+            n=reactive(default=0),
+            s=reactive(default='view'),
+            items=reactive(default_factory=list),
+        )
+
+    def _fresh(self) -> StubChannel:
+        ch = self.Cls()
+        ch.__dict__['n'] = 0
+        ch.__dict__['s'] = 'view'
+        ch.__dict__['items'] = []
+        return ch
+
+    def test_batch_emits_single_message(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            async with ch.batch():
+                ch.n = 5
+                ch.s = 'edit'
+            assert ch.single_broadcasts == []
+            assert ch.batch_broadcasts == [{'n': 5, 's': 'edit'}]
+            assert ch.n == 5
+            assert ch.s == 'edit'
+        asyncio.run(go())
+
+    def test_multiple_writes_same_field_keep_final(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            async with ch.batch():
+                ch.n = 1
+                ch.n = 2
+                ch.n = 3
+            assert ch.batch_broadcasts == [{'n': 3}]
+        asyncio.run(go())
+
+    def test_net_zero_field_is_omitted(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            async with ch.batch():
+                ch.n = 99
+                ch.n = 0  # back to default
+                ch.s = 'edit'
+            assert ch.batch_broadcasts == [{'s': 'edit'}]
+        asyncio.run(go())
+
+    def test_empty_batch_sends_nothing(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            async with ch.batch():
+                pass
+            assert ch.single_broadcasts == []
+            assert ch.batch_broadcasts == []
+        asyncio.run(go())
+
+    def test_batch_read_sees_pending(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            async with ch.batch():
+                ch.n = 42
+                assert ch.n == 42, "read inside batch must see pending value"
+            assert ch.n == 42
+        asyncio.run(go())
+
+    def test_nested_batch_merges(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            async with ch.batch():
+                ch.n = 1
+                async with ch.batch():
+                    ch.s = 'edit'
+                # Still no broadcast yet — outer batch pending
+                assert ch.batch_broadcasts == []
+            assert ch.batch_broadcasts == [{'n': 1, 's': 'edit'}]
+        asyncio.run(go())
+
+    def test_exception_discards_buffer(self, caplog: Any) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            with caplog.at_level(logging.WARNING, logger='rxdjango.state'):
+                with pytest.raises(RuntimeError, match="boom"):
+                    async with ch.batch():
+                        ch.n = 99
+                        ch.s = 'edit'
+                        raise RuntimeError("boom")
+
+            assert ch.single_broadcasts == []
+            assert ch.batch_broadcasts == []
+            assert ch.n == 0, "n must remain at pre-batch value"
+            assert ch.s == 'view', "s must remain at pre-batch value"
+            assert any('Discarding' in rec.message
+                       for rec in caplog.records), \
+                "A warning naming the discard must be logged"
+        asyncio.run(go())
+
+    def test_inner_exception_preserves_outer(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            async with ch.batch():
+                ch.n = 1
+                try:
+                    async with ch.batch():
+                        ch.s = 'edit'
+                        raise RuntimeError("inner boom")
+                except RuntimeError:
+                    pass
+                # Outer batch continues with its own pending writes
+                ch.items = [10]
+            # Inner frame was discarded; outer commits n and items
+            assert ch.batch_broadcasts == [{'n': 1, 'items': [10]}]
+            assert ch.s == 'view', "inner-only write was discarded"
+        asyncio.run(go())
+
+    def test_container_mutation_in_batch_buffers(self) -> None:
+        async def go() -> None:
+            ch = self._fresh()
+            async with ch.batch():
+                ch.items.append(1)
+                ch.items.append(2)
+            assert ch.single_broadcasts == []
+            assert ch.batch_broadcasts == [{'items': [1, 2]}]
+        asyncio.run(go())
+
+
+# ---------------------------------------------------------------------------
+# Inheritance
+# ---------------------------------------------------------------------------
+
+
+class TestInheritance:
+    def test_subclass_inherits_fields(self) -> None:
+        # Build base and derived manually, as metaclass would.
+        base_n = reactive(default=0)
+        Base = type('Base', (StubChannel,), {'n': base_n})
+        base_n.__set_name__(Base, 'n')
+        Base.__reactive_fields__ = {'n': base_n}
+
+        child_s = reactive(default='hi')
+        Child = type('Child', (Base,), {'s': child_s})
+        child_s.__set_name__(Child, 's')
+        Child.__reactive_fields__ = {'n': base_n, 's': child_s}
+
+        ch = Child()
+        ch.__dict__['n'] = 0
+        ch.__dict__['s'] = 'hi'
+        assert ch.n == 0
+        assert ch.s == 'hi'
+
+
+# ---------------------------------------------------------------------------
+# Equality edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEquality:
+    def test_equal_but_distinct_dict_skips(self) -> None:
+        async def go() -> None:
+            Cls = make_channel_with_fields(
+                m=reactive(default_factory=dict),
+            )
+            ch = Cls()
+            ch.__dict__['m'] = {'a': 1}
+            ch.m = {'a': 1}  # equal but distinct object
+            await drain()
+            assert ch.single_broadcasts == []
+        asyncio.run(go())
+
+    def test_nan_always_broadcasts(self) -> None:
+        async def go() -> None:
+            Cls = make_channel_with_fields(x=reactive(default=float('nan')))
+            ch = Cls()
+            ch.__dict__['x'] = float('nan')
+            ch.x = float('nan')  # NaN != NaN, so this broadcasts
+            await drain()
+            assert len(ch.single_broadcasts) == 1
+        asyncio.run(go())

--- a/rxdjango/tests/test_ts_reactive_gen.py
+++ b/rxdjango/tests/test_ts_reactive_gen.py
@@ -1,0 +1,139 @@
+"""Unit tests for the TypeScript generator with reactive fields.
+
+Verifies that __reactive_fields__ produces the correct TS interface
+and that the class body reflects the new runtime state shape.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from rxdjango.state import reactive
+from rxdjango.ts.channels import _annotation_to_ts
+
+
+# ---------------------------------------------------------------------------
+# _annotation_to_ts helper
+# ---------------------------------------------------------------------------
+
+
+class TestAnnotationToTs:
+    def test_int(self) -> None:
+        assert _annotation_to_ts(int) == 'number'
+
+    def test_str(self) -> None:
+        assert _annotation_to_ts(str) == 'string'
+
+    def test_bool(self) -> None:
+        assert _annotation_to_ts(bool) == 'boolean'
+
+    def test_float(self) -> None:
+        assert _annotation_to_ts(float) == 'number'
+
+    def test_none_type(self) -> None:
+        assert _annotation_to_ts(type(None)) == 'null'
+
+    def test_bare_list(self) -> None:
+        assert _annotation_to_ts(list) == 'any[]'
+
+    def test_list_of_int(self) -> None:
+        assert _annotation_to_ts(list[int]) == 'number[]'
+
+    def test_list_of_str(self) -> None:
+        assert _annotation_to_ts(list[str]) == 'string[]'
+
+    def test_set_of_str(self) -> None:
+        assert _annotation_to_ts(set[str]) == 'string[]'
+
+    def test_dict_str_int(self) -> None:
+        result = _annotation_to_ts(dict[str, int])
+        assert result == '{ [key: string]: number }'
+
+    def test_bare_dict(self) -> None:
+        # dict without subscript is in TYPEMAP as string->string
+        assert _annotation_to_ts(dict) == '{ [key: string]: string }'
+
+    def test_optional_int(self) -> None:
+        result = _annotation_to_ts(Optional[int])
+        assert result == 'number | null'
+
+    def test_unknown_falls_back_to_any(self) -> None:
+        class Custom:
+            pass
+        assert _annotation_to_ts(Custom) == 'any'
+
+    def test_none_annotation(self) -> None:
+        assert _annotation_to_ts(None) == 'null'
+
+
+# ---------------------------------------------------------------------------
+# __reactive_fields__ integration with TS interface generation
+# ---------------------------------------------------------------------------
+
+
+class TestReactiveFieldsInTsOutput:
+    """Verify that reactive fields produce the correct TS interface snippet.
+
+    We build a simulated context_channel_class by hand (no Django) and
+    call the same code path the generator uses.
+    """
+
+    def _make_runtime_interface(self, reactive_fields: dict) -> list[str]:
+        """Replicate the interface-emission block from generate_ts_class."""
+        runtime_type = 'MyChannelRuntimeState'
+        field_types = {
+            fname: _annotation_to_ts(field.annotation)
+            for fname, field in reactive_fields.items()
+        }
+        lines = [f"export interface {runtime_type} {{"]
+        lines += [f"  {var}: {ts_type};" for var, ts_type in field_types.items()]
+        lines += ["}\n"]
+        return lines
+
+    def _make_field(self, annotation, **kwargs):
+        field = reactive(**kwargs)
+        field.annotation = annotation
+        return field
+
+    def test_scalar_fields(self) -> None:
+        fields = {
+            'notifications': self._make_field(int, default=0),
+            'mode': self._make_field(str, default='view'),
+        }
+        lines = self._make_runtime_interface(fields)
+        assert 'export interface MyChannelRuntimeState {' in lines[0]
+        assert '  notifications: number;' in lines
+        assert '  mode: string;' in lines
+
+    def test_list_field(self) -> None:
+        fields = {
+            'typing_users': self._make_field(list[int], default_factory=list),
+        }
+        lines = self._make_runtime_interface(fields)
+        assert '  typing_users: number[];' in lines
+
+    def test_dict_field(self) -> None:
+        fields = {
+            'metadata': self._make_field(dict[str, str], default_factory=dict),
+        }
+        lines = self._make_runtime_interface(fields)
+        assert '  metadata: { [key: string]: string };' in lines
+
+    def test_no_reactive_fields_means_null_runtimeState(self) -> None:
+        # When __reactive_fields__ is empty, the generator emits:
+        #   runtimeState = null;
+        # We just verify our flag detection logic is correct.
+        class FakeChannel:
+            __reactive_fields__ = {}
+
+        assert not FakeChannel.__reactive_fields__, \
+            "Empty dict is falsy — generator should skip runtime type"
+
+    def test_reactive_fields_truthy_triggers_interface(self) -> None:
+        field = self._make_field(int, default=0)
+        field.name = 'count'
+
+        class FakeChannel:
+            __reactive_fields__ = {'count': field}
+
+        assert FakeChannel.__reactive_fields__, \
+            "Non-empty dict triggers runtime type generation"

--- a/rxdjango/ts/channels.py
+++ b/rxdjango/ts/channels.py
@@ -13,6 +13,54 @@ from . import (header, interface_name, diff, get_ts_type, snake_to_camel,
 from .interfaces import mappings as _field_type_mappings
 
 
+def _annotation_to_ts(annotation: typing.Any) -> str:
+    """Convert a Python type annotation to a TypeScript type string.
+
+    Handles primitive scalars via TYPEMAP, plus generics such as
+    ``list[int]``, ``dict[str, bool]``, and ``set[str]``.
+    Falls back to ``any`` for unknown types.
+    """
+    if annotation is None or annotation is type(None):
+        return 'null'
+
+    # Plain primitives and well-known types
+    if annotation in TYPEMAP:
+        return TYPEMAP[annotation]
+
+    # Generics: list[X], set[X], dict[K, V]
+    origin = typing.get_origin(annotation)
+    args = typing.get_args(annotation)
+
+    if origin in (list, set):
+        inner = _annotation_to_ts(args[0]) if args else 'any'
+        return f'{inner}[]'
+
+    if origin is dict:
+        key_ts = _annotation_to_ts(args[0]) if args else 'string'
+        val_ts = _annotation_to_ts(args[1]) if len(args) > 1 else 'any'
+        return f'{{ [key: {key_ts}]: {val_ts} }}'
+
+    # Optional[X] / Union[X, None]
+    if origin is typing.Union:
+        non_none = [a for a in args if a is not type(None)]
+        has_none = any(a is type(None) for a in args)
+        ts_parts = [_annotation_to_ts(a) for a in non_none]
+        result = ' | '.join(ts_parts)
+        if has_none:
+            result += ' | null'
+        return result
+
+    # Bare list / dict / set without subscript
+    if annotation is list:
+        return 'any[]'
+    if annotation is set:
+        return 'any[]'
+    if annotation is dict:
+        return '{ [key: string]: any }'
+
+    return 'any'
+
+
 def create_app_channels(app, apply_changes=True, force=False):
     consumer_urlpatterns = list_consumer_patterns(app)
     if not consumer_urlpatterns:
@@ -521,7 +569,7 @@ def generate_ts_class(context_channel_class, urlpattern, import_types):
     if context_channel_class.many:
         state_type += '[]'
 
-    if getattr(context_channel_class, 'RuntimeState', False):
+    if context_channel_class.__reactive_fields__:
         runtime_type = f'{context_channel_class.__name__}RuntimeState'
         types = f'{state_type}, {runtime_type}'
     else:
@@ -549,13 +597,16 @@ def generate_ts_class(context_channel_class, urlpattern, import_types):
 
     if runtime_type:
         code.append(f'  runtimeState: {runtime_type} | undefined')
-        types = typing.get_type_hints(context_channel_class.RuntimeState)
+        field_types = {
+            fname: _annotation_to_ts(field.annotation)
+            for fname, field in context_channel_class.__reactive_fields__.items()
+        }
 
         code = [
             f"export interface {runtime_type} {{"
         ] + [
-            f"  {var}: {TYPEMAP[_type]};"
-            for var, _type in types.items()
+            f"  {var}: {ts_type};"
+            for var, ts_type in field_types.items()
         ] + [
             "}\n"
         ] + code

--- a/test_project/react_test/channels.py
+++ b/test_project/react_test/channels.py
@@ -3,12 +3,18 @@ from channels.db import database_sync_to_async
 from rxdjango.actions import action
 from rxdjango.channels import ContextChannel
 from rxdjango.operations import SAVE, CREATE, DELETE
+from rxdjango.state import reactive
 
 from .models import Asset, Job, Participant, Task
 from .serializers import JobNestedSerializer, TaskSerializer, AssetSerializer
 
 
 class JobContextChannel(ContextChannel):
+
+    # Reactive fields — per-connection ephemeral state
+    typing_users: list[int] = reactive(default_factory=list)
+    unread_count: int = reactive(default=0)
+    view_mode: str = reactive(default='view')
 
     class Meta:
         state = JobNestedSerializer()
@@ -83,6 +89,7 @@ class JobContextChannel(ContextChannel):
     @action
     async def delete_asset(self, asset_id: int) -> dict:
         return await database_sync_to_async(self._delete_asset)(asset_id)
+
     def _delete_asset(self, asset_id: int) -> dict:
         asset = Asset.objects.get(pk=asset_id, job_id=self.kwargs['job_id'])
         asset.delete()
@@ -90,4 +97,26 @@ class JobContextChannel(ContextChannel):
             'assetId': asset_id,
             'deleted': True,
         }
+
+    # --- Reactive state actions ---
+
+    @action
+    async def start_typing(self, user_id: int) -> dict:
+        if user_id not in self.typing_users:
+            self.typing_users.append(user_id)
+        return {'ok': True}
+
+    @action
+    async def stop_typing(self, user_id: int) -> dict:
+        if user_id in self.typing_users:
+            self.typing_users.remove(user_id)
+        return {'ok': True}
+
+    @action
+    async def mark_all_read_and_switch_to_edit(self) -> dict:
+        async with self.batch():
+            self.unread_count = 0
+            self.view_mode = 'edit'
+            self.typing_users.clear()
+        return {'ok': True}
 

--- a/test_project/react_test/tests/test_runtime_state.py
+++ b/test_project/react_test/tests/test_runtime_state.py
@@ -1,0 +1,336 @@
+"""Integration tests for reactive state on ContextChannel.
+
+Tests the full WebSocket lifecycle for reactive fields: initial delivery,
+single-field updates, container mutation, batching, idempotency, multi-client
+broadcast, and reconnect-reset semantics.
+
+Run from test_project/:
+    python manage.py test react_test.tests.test_runtime_state
+"""
+import json
+import asyncio
+
+from channels.testing import WebsocketCommunicator
+from channels.routing import URLRouter
+from django.test import TransactionTestCase
+from django.urls import path
+from rest_framework.authtoken.models import Token
+
+from users.models import User as AuthUser
+from react_test.models import User, Project, Participant, Job
+from react_test.channels import JobContextChannel
+from rxdjango.mongo import MongoSignalWriter
+from rxdjango.redis import RedisSession
+from rxdjango.transaction_manager import TransactionBroadcastManager
+
+# Message receive timeout in seconds
+T = 1
+
+websocket_urlpatterns = [
+    path('ws/job/<int:job_id>/', JobContextChannel.as_asgi()),
+]
+
+
+class RuntimeStateTest(TransactionTestCase):
+    """Integration tests for reactive state fields."""
+
+    def get_ws(self, job_id):
+        application = URLRouter(websocket_urlpatterns)
+        return WebsocketCommunicator(application, f'/ws/job/{job_id}/')
+
+    def setUp(self):
+        self.auth_user = AuthUser.objects.create_user(
+            login='testuser', password='testpass',
+        )
+        self.token = Token.objects.create(user=self.auth_user)
+        self.auth = json.dumps({'token': self.token.key})
+
+        user1 = User.objects.create(name='User1')
+        project = Project.objects.create(name='Project1')
+        part1 = Participant.objects.create(
+            project=project, user=user1,
+            name='Participant1', role='Developer',
+        )
+        job = Job.objects.create(project=project, name='Job1')
+        job.tasks.create(name='Task1', developer=part1)
+
+        self.job = job
+        self.project = project
+
+        TransactionBroadcastManager._clear()
+        RedisSession.init_database(JobContextChannel)
+        MongoSignalWriter(JobContextChannel).init_database()
+
+    def tearDown(self):
+        AuthUser.objects.all().delete()
+        Job.objects.all().delete()
+        Project.objects.all().delete()
+        User.objects.all().delete()
+
+    # -----------------------------------------------------------------------
+    # Helpers
+    # -----------------------------------------------------------------------
+
+    async def connect_and_auth(self):
+        ws = self.get_ws(self.job.id)
+        connected, _ = await ws.connect()
+        assert connected
+        await ws.send_to(text_data=self.auth)
+        return ws
+
+    async def safe_disconnect(self, ws):
+        try:
+            await ws.disconnect()
+        except asyncio.CancelledError:
+            pass
+
+    async def drain_initial_state(self, ws):
+        """Read messages until we see the end_initial_state marker.
+
+        Returns a tuple (all_messages, runtime_vars_message) where
+        runtime_vars_message is the runtimeVars dict sent after state load
+        (or None if not received).
+        """
+        all_messages = []
+        runtime_vars = None
+        while True:
+            try:
+                resp = await ws.receive_output(timeout=T)
+                data = json.loads(resp['text'])
+                all_messages.append(data)
+
+                if isinstance(data, dict) and data.get('type') == 'runtimeVars':
+                    runtime_vars = data
+                    # After runtimeVars there are no more setup messages
+                    break
+
+                if isinstance(data, list):
+                    for item in data:
+                        if item.get('_operation') == 'end_initial_state':
+                            # Flush remaining messages briefly
+                            continue
+            except asyncio.TimeoutError:
+                break
+        return all_messages, runtime_vars
+
+    async def call_action(self, ws, action_name, *params, call_id=1):
+        """Call an action and collect response + any reactive messages."""
+        await ws.send_to(text_data=json.dumps({
+            'callId': call_id,
+            'action': action_name,
+            'params': list(params),
+        }))
+
+        response = None
+        reactive_messages = []
+
+        while True:
+            try:
+                resp = await ws.receive_output(timeout=T)
+                data = json.loads(resp['text'])
+
+                if isinstance(data, dict) and data.get('type') == 'actionResponse':
+                    response = data
+                    # Keep reading briefly for reactive messages
+                    continue
+                if isinstance(data, dict) and data.get('type') in ('runtimeVar', 'runtimeVars'):
+                    reactive_messages.append(data)
+            except asyncio.TimeoutError:
+                break
+
+        return response, reactive_messages
+
+    async def collect_reactive(self, ws, timeout=T):
+        """Collect any reactive messages that arrive within timeout."""
+        messages = []
+        while True:
+            try:
+                resp = await ws.receive_output(timeout=timeout)
+                data = json.loads(resp['text'])
+                if isinstance(data, dict) and data.get('type') in ('runtimeVar', 'runtimeVars'):
+                    messages.append(data)
+            except asyncio.TimeoutError:
+                break
+        return messages
+
+    # -----------------------------------------------------------------------
+    # Tests
+    # -----------------------------------------------------------------------
+
+    async def test_1_initial_state_includes_reactive_defaults(self):
+        """On connect, client receives a runtimeVars message with all defaults."""
+        ws = await self.connect_and_auth()
+        try:
+            _, runtime_vars = await self.drain_initial_state(ws)
+
+            assert runtime_vars is not None, \
+                "Expected a runtimeVars message after initial state load"
+            assert runtime_vars['type'] == 'runtimeVars'
+            vars_ = runtime_vars['vars']
+            assert vars_['typing_users'] == []
+            assert vars_['unread_count'] == 0
+            assert vars_['view_mode'] == 'view'
+        finally:
+            await self.safe_disconnect(ws)
+
+    async def test_2_single_scalar_update(self):
+        """start_typing broadcasts a runtimeVar with the updated list."""
+        ws = await self.connect_and_auth()
+        try:
+            await self.drain_initial_state(ws)
+
+            response, reactive = await self.call_action(ws, 'start_typing', 1)
+            assert response is not None
+            assert 'error' not in response
+
+            assert len(reactive) == 1
+            msg = reactive[0]
+            assert msg['type'] == 'runtimeVar'
+            assert msg['var'] == 'typing_users'
+            assert msg['value'] == [1]
+        finally:
+            await self.safe_disconnect(ws)
+
+    async def test_3_container_mutation_order(self):
+        """Sequential start_typing calls produce cumulative updates."""
+        ws = await self.connect_and_auth()
+        try:
+            await self.drain_initial_state(ws)
+
+            _, r1 = await self.call_action(ws, 'start_typing', 1, call_id=1)
+            _, r2 = await self.call_action(ws, 'start_typing', 2, call_id=2)
+
+            assert len(r1) == 1 and r1[0]['value'] == [1]
+            assert len(r2) == 1 and r2[0]['value'] == [1, 2]
+        finally:
+            await self.safe_disconnect(ws)
+
+    async def test_4_removal_via_in_place_mutation(self):
+        """stop_typing produces a runtimeVar with the correct remaining list."""
+        ws = await self.connect_and_auth()
+        try:
+            await self.drain_initial_state(ws)
+
+            await self.call_action(ws, 'start_typing', 1, call_id=1)
+            await self.call_action(ws, 'start_typing', 2, call_id=2)
+            _, reactive = await self.call_action(ws, 'stop_typing', 1, call_id=3)
+
+            assert len(reactive) == 1
+            assert reactive[0]['value'] == [2]
+        finally:
+            await self.safe_disconnect(ws)
+
+    async def test_5_batched_update_single_message(self):
+        """mark_all_read_and_switch_to_edit produces exactly one runtimeVars message."""
+        ws = await self.connect_and_auth()
+        try:
+            await self.drain_initial_state(ws)
+
+            # Seed some state first
+            await self.call_action(ws, 'start_typing', 1, call_id=1)
+
+            response, reactive = await self.call_action(
+                ws, 'mark_all_read_and_switch_to_edit', call_id=2
+            )
+            assert response is not None
+            assert 'error' not in response
+
+            # Must be exactly one message of type runtimeVars
+            assert len(reactive) == 1, \
+                f"Expected 1 runtimeVars, got {len(reactive)}: {reactive}"
+            msg = reactive[0]
+            assert msg['type'] == 'runtimeVars', \
+                f"Expected runtimeVars, got {msg['type']}"
+            vars_ = msg['vars']
+            assert vars_['unread_count'] == 0
+            assert vars_['view_mode'] == 'edit'
+            assert vars_['typing_users'] == []
+        finally:
+            await self.safe_disconnect(ws)
+
+    async def test_6_no_broadcast_when_value_unchanged(self):
+        """Calling start_typing for a user already in the list produces no message."""
+        ws = await self.connect_and_auth()
+        try:
+            await self.drain_initial_state(ws)
+
+            # Add user 1 first
+            await self.call_action(ws, 'start_typing', 1, call_id=1)
+
+            # Call again with same user — the channel's if-guard prevents the write
+            response, reactive = await self.call_action(ws, 'start_typing', 1, call_id=2)
+            assert response is not None
+
+            assert reactive == [], \
+                f"Expected no reactive messages, got: {reactive}"
+        finally:
+            await self.safe_disconnect(ws)
+
+    async def test_7_two_clients_one_channel(self):
+        """An action from client A sends runtimeVar to both A and B."""
+        ws_a = await self.connect_and_auth()
+        ws_b = await self.connect_and_auth()
+        try:
+            await self.drain_initial_state(ws_a)
+            await self.drain_initial_state(ws_b)
+
+            # A calls start_typing
+            await ws_a.send_to(text_data=json.dumps({
+                'callId': 1,
+                'action': 'start_typing',
+                'params': [42],
+            }))
+
+            # Both A and B should receive the runtimeVar
+            a_msgs = await self.collect_reactive(ws_a)
+            b_msgs = await self.collect_reactive(ws_b)
+
+            assert any(m.get('var') == 'typing_users' for m in a_msgs), \
+                f"A did not receive typing_users update: {a_msgs}"
+            assert any(m.get('var') == 'typing_users' for m in b_msgs), \
+                f"B did not receive typing_users update: {b_msgs}"
+        finally:
+            await self.safe_disconnect(ws_a)
+            await self.safe_disconnect(ws_b)
+
+    async def test_8_reconnect_resets_reactive_state(self):
+        """Reconnecting client receives fresh defaults, not prior session values."""
+        # First connection: mutate state
+        ws_a = await self.connect_and_auth()
+        await self.drain_initial_state(ws_a)
+        await self.call_action(ws_a, 'start_typing', 99, call_id=1)
+        await self.safe_disconnect(ws_a)
+
+        # Second connection: fresh session — should see defaults
+        ws_b = await self.connect_and_auth()
+        try:
+            _, runtime_vars = await self.drain_initial_state(ws_b)
+
+            assert runtime_vars is not None
+            assert runtime_vars['vars']['typing_users'] == [], \
+                "Reconnect must reset reactive state to defaults"
+            assert runtime_vars['vars']['view_mode'] == 'view'
+            assert runtime_vars['vars']['unread_count'] == 0
+        finally:
+            await self.safe_disconnect(ws_b)
+
+    async def test_9_batch_net_zero_field_omitted(self):
+        """Fields whose value doesn't change during a batch are not broadcast."""
+        ws = await self.connect_and_auth()
+        try:
+            await self.drain_initial_state(ws)
+
+            # mark_all_read_and_switch_to_edit sets unread_count=0, view_mode='edit',
+            # typing_users=[]. unread_count is already 0, so it may be omitted.
+            # view_mode changes from 'view' to 'edit', so it must be present.
+            response, reactive = await self.call_action(
+                ws, 'mark_all_read_and_switch_to_edit', call_id=1
+            )
+            assert len(reactive) == 1
+            vars_ = reactive[0]['vars']
+            assert 'view_mode' in vars_, "view_mode changed, must be in batch"
+            # unread_count was already 0 — may or may not be included
+            # (implementation may or may not deduplicate against defaults)
+            # We only assert the changed field is present.
+        finally:
+            await self.safe_disconnect(ws)


### PR DESCRIPTION
Reactive state redesign across backend, frontend, tests, and docs. This squashes the full branch diff on top of main into one commit.

rxdjango/state.py:
- Add reactive(default=, default_factory=) field factory and ReactiveField descriptor
- Add ReactiveList, ReactiveDict, and ReactiveSet proxy containers that broadcast on in-place mutation
- Add async batch() support with transactional buffering, nested merge behavior, and rollback on exception

rxdjango/channels.py:
- Collect reactive field declarations from channel classes and bases into __reactive_fields__
- Initialize per-connection reactive defaults during channel construction
- Replace RuntimeState / runtime_state / set_runtime_var() with field-based broadcast helpers and batch()

rxdjango/consumers.py:
- Send initial runtimeVars payload after state load for channels with reactive fields
- Update protocol documentation for runtimeVars delivery

rxdjango/ts/channels.py:
- Generate reactive runtime field types from Python annotations
- Preserve runtimeVars interface generation for scalar and container field shapes

rxdjango-react/src/ContextChannel.ts:
- Handle runtimeVars batch payloads on the client
- Keep runtime state updates aligned with the new backend batching semantics

Runtime-Refactor-FDD.md:
- Add design document for replacing RuntimeState with reactive() descriptors and auto-proxy containers
- Record decisions for reconnect behavior, batch exception semantics, and sync-context writes

Documentation:
- Update docs/using-rxdjango.rst, docs/context-channel.rst, and docs/api-reference.rst for reactive fields and batch()
- Add CHANGELOG.md entry for the breaking v0.3.0 API change

Tests:
- Add backend unit coverage for reactive fields, proxy containers, batching, inheritance, and TS generation
- Add frontend tests for runtimeVars batching and websocket handling
- Add integration coverage for connection defaults, list mutation, batching, reconnect reset, idempotence, and multi-client delivery

Branch summary:
- 17 tracked files changed
- 2529 insertions, 58 deletions
- Replaces the runtime_state / set_runtime_var API with reactive() field descriptors end-to-end